### PR TITLE
Avoid using the GITHUB_TOKEN for pr creation

### DIFF
--- a/.github/chainguard/self.prepare-rebase-on-upstream.create-pr.sts.yaml
+++ b/.github/chainguard/self.prepare-rebase-on-upstream.create-pr.sts.yaml
@@ -1,12 +1,12 @@
 issuer: https://token.actions.githubusercontent.com
 
-subject: repo:open-telemetry/opentelemetry-ebpf-profiler:ref:refs/heads/datadog
+subject: repo:DataDog/opentelemetry-ebpf-profiler:ref:refs/heads/datadog
 
 claim_pattern:
   event_name: workflow_dispatch
   ref: refs/heads/datadog
   ref_protected: "true"
-  job_workflow_ref: open-telemetry/opentelemetry-ebpf-profiler/.github/workflows/prepare-rebase-on-upstream.yml@refs/heads/datadog
+  job_workflow_ref: DataDog/opentelemetry-ebpf-profiler/.github/workflows/prepare-rebase-on-upstream.yml@refs/heads/datadog
 
 permissions:
   pull_requests: write

--- a/.github/chainguard/self.prepare-rebase-on-upstream.create-pr.sts.yaml
+++ b/.github/chainguard/self.prepare-rebase-on-upstream.create-pr.sts.yaml
@@ -1,0 +1,12 @@
+issuer: https://token.actions.githubusercontent.com
+
+subject: repo:open-telemetry/opentelemetry-ebpf-profiler:ref:refs/heads/datadog
+
+claim_pattern:
+  event_name: workflow_dispatch
+  ref: refs/heads/datadog
+  ref_protected: "true"
+  job_workflow_ref: open-telemetry/opentelemetry-ebpf-profiler/.github/workflows/prepare-rebase-on-upstream.yml@refs/heads/datadog
+
+permissions:
+  pull_requests: write

--- a/.github/workflows/prepare-rebase-on-upstream.yml
+++ b/.github/workflows/prepare-rebase-on-upstream.yml
@@ -6,8 +6,13 @@ jobs:
   prepare:
     runs-on: ubuntu-latest
     permissions:
-      pull-requests: write
+      id-token: write # Needed to federate tokens
     steps:
+      - uses: DataDog/dd-octo-sts-action@acaa02eee7e3bb0839e4272dacb37b8f3b58ba80 # v1.0.3
+        id: octo-sts
+        with:
+          scope: open-telemetry/opentelemetry-ebpf-profiler
+          policy: self.prepare-rebase-on-upstream.create-pr
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
@@ -44,10 +49,10 @@ jobs:
         run: |
           gh pr create -R ${{ github.repository }} --base main --head rebase-on-upstream --title "Rebase datadog on upstream/main" --body "This PR is to rebase datadog branch on main branch"
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
 
       - name: Add comment
         run: |
           gh pr comment rebase-on-upstream -R ${{ github.repository }} --body "Please close and re-open this PR to trigger the tests."
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.octo-sts.outputs.token }}


### PR DESCRIPTION
Replace GITHUB_TOKEN usage with dd-octo-sts for pull request creation. The following steps were performed:

- Add trust policy for self.prepare-rebase-on-upstream.create-pr
- Update workflow to use dd-octo-sts-action for token federation
- Replace GITHUB_TOKEN with dd-octo-sts token in PR creation and commenting
- Remove job-level pull-requests permission (now handled by trust policy)

This allows deactivating the insecure github workflow permission "Allow GITHUB_TOKEN to create/approve PRs".