### PR TITLE
Improve Go TLS g offset extraction

### DIFF
--- a/interpreter/golabels/tls_amd64.go
+++ b/interpreter/golabels/tls_amd64.go
@@ -7,7 +7,10 @@ package golabels // import "go.opentelemetry.io/ebpf-profiler/interpreter/golabe
 
 import (
 	log "github.com/sirupsen/logrus"
+	"go.opentelemetry.io/ebpf-profiler/asm/amd"
+	e "go.opentelemetry.io/ebpf-profiler/asm/expression"
 	"go.opentelemetry.io/ebpf-profiler/libpf/pfelf"
+	"go.opentelemetry.io/ebpf-profiler/nativeunwind/elfunwindinfo"
 	"golang.org/x/arch/x86/x86asm"
 )
 
@@ -16,33 +19,63 @@ import (
 // may be dynamic relocating going on so just read it from a known
 // symbol if possible.
 func extractTLSGOffset(f *pfelf.File) (int32, error) {
+	var addr int64
 	syms, err := f.ReadSymbols()
 	if err != nil {
-		return 0, err
+		gopclntab, err2 := elfunwindinfo.NewGopclntab(f)
+		if err2 != nil {
+			return 0, err2
+		}
+		defer gopclntab.Close()
+		funcPc, err2 := gopclntab.LookupFunction("runtime.stackcheck")
+		if err2 != nil {
+			return 0, err2
+		}
+		addr = int64(funcPc)
+	} else {
+		sym, err2 := syms.LookupSymbol("runtime.stackcheck.abi0")
+		if err2 != nil {
+			// Binary must be stripped, hope default is correct and warn.
+			log.Warnf("Failed to find stackcheck symbol, Go labels might not work: %v", err2)
+			return -8, err2
+		}
+		addr = int64(sym.Address)
 	}
+
 	// Dump of assembler code for function runtime.stackcheck:
 	// 0x0000000000470080 <+0>:     mov    %fs:0xfffffffffffffff8,%rax
-	sym, err := syms.LookupSymbol("runtime.stackcheck.abi0")
-	if err != nil {
-		// Binary must be stripped, hope default is correct and warn.
-		log.Warnf("Failed to find stackcheck symbol, Go labels might not work: %v", err)
-		return -8, nil
-	}
-	b, err := f.VirtualMemory(int64(sym.Address), 10, 10)
+
+	// dockerd has a different assembly code for stackcheck with 2 movs:
+	//  0x00000000007ec320 <+0>:	mov    $0xfffffffffffffff8,%rcx
+	//  0x00000000007ec327 <+7>:	mov    %fs:(%rcx),%rax
+	code, err := f.VirtualMemory(addr, 16, 16)
 	if err != nil {
 		return 0, err
 	}
 
-	i, err := x86asm.Decode(b, 64)
-	if err != nil {
-		return 0, err
-	}
-	if i.Op == x86asm.MOV {
-		mem, ok := i.Args[1].(x86asm.Mem)
-		if ok {
+	offset := e.NewImmediateCapture("offset")
+	it := amd.NewInterpreterWithCode(code)
+	for {
+		op, err := it.Step()
+		if err != nil {
+			break
+		}
+		if op.Op != x86asm.MOV {
+			continue
+		}
+		mem, ok := op.Args[1].(x86asm.Mem)
+		if !ok || mem.Segment != x86asm.FS {
+			continue
+		}
+		if mem.Base == 0 {
 			return int32(mem.Disp), nil
 		}
+		actual := it.Regs.GetX86(mem.Base)
+		if actual.Match(offset) {
+			return int32(offset.CapturedValue()), nil
+		}
 	}
+
 	log.Warnf("Failed to decode stackcheck symbol, Go label collection might not work")
 	return -8, nil
 }

--- a/interpreter/golabels/tls_arm64.go
+++ b/interpreter/golabels/tls_arm64.go
@@ -8,6 +8,7 @@ package golabels // import "go.opentelemetry.io/ebpf-profiler/interpreter/golabe
 import (
 	log "github.com/sirupsen/logrus"
 	"go.opentelemetry.io/ebpf-profiler/libpf/pfelf"
+	"go.opentelemetry.io/ebpf-profiler/nativeunwind/elfunwindinfo"
 	"golang.org/x/arch/arm64/arm64asm"
 )
 
@@ -27,18 +28,31 @@ func extractTLSGOffset(f *pfelf.File) (int32, error) {
 		return 0, err
 	}
 
+	var addr int64
 	syms, err := f.ReadSymbols()
 	if err != nil {
-		return 0, err
+		gopclntab, err2 := elfunwindinfo.NewGopclntab(f)
+		if err2 != nil {
+			return 0, err2
+		}
+		defer gopclntab.Close()
+		funcPc, err2 := gopclntab.LookupFunction("runtime.load_g")
+		if err2 != nil {
+			return 0, err2
+		}
+		addr = int64(funcPc)
+	} else {
+		sym, err2 := syms.LookupSymbol("runtime.load_g.abi0")
+		if err2 != nil {
+			// Binary must be stripped, just warn and return 0 and we'll rely on r28.
+			log.Warnf("Failed to find load_g symbol in cgo enabled Go binary "+
+				"label collection in CGO frames may not work: %v", err2)
+			return 0, nil
+		}
+		addr = int64(sym.Address)
 	}
-	sym, err := syms.LookupSymbol("runtime.load_g.abi0")
-	if err != nil {
-		// Binary must be stripped, just warn and return 0 and we'll rely on r28.
-		log.Warnf("Failed to find load_g symbol in cgo enabled Go binary "+
-			"label collection in CGO frames may not work: %v", err)
-		return 0, nil
-	}
-	b, err := f.VirtualMemory(int64(sym.Address), 32, 32)
+
+	b, err := f.VirtualMemory(addr, 32, 32)
 	if err != nil {
 		return 0, err
 	}

--- a/nativeunwind/elfunwindinfo/elfgopclntab.go
+++ b/nativeunwind/elfunwindinfo/elfgopclntab.go
@@ -10,6 +10,7 @@ package elfunwindinfo // import "go.opentelemetry.io/ebpf-profiler/nativeunwind/
 import (
 	"bytes"
 	"debug/elf"
+	"errors"
 	"fmt"
 	"go/version"
 	"io"
@@ -496,6 +497,17 @@ func (g *Gopclntab) mapPcval(offs int32, startPc, pc uint) (int32, bool) {
 		}
 	}
 	return p.val, true
+}
+
+func (g *Gopclntab) LookupFunction(funcName string) (uintptr, error) {
+	for i := 0; i < g.numFuncs; i++ {
+		mapPc, funcOff := g.getFuncMapEntry(i)
+		funcPc, fun := g.getFunc(funcOff)
+		if fun != nil && mapPc == funcPc && getString(g.funcnametab, int(fun.nameOff)) == funcName {
+			return funcPc, nil
+		}
+	}
+	return 0, errors.New("function not found")
 }
 
 // Symbolize returns the file, line and function information for given PC


### PR DESCRIPTION
- Use gopclntab to lookup function address when symbol table is not available
- More robust assembly handling for amd64