### PR TITLE
ruby: fix panic when logging invalid string

### DIFF
--- a/interpreter/ruby/ruby.go
+++ b/interpreter/ruby/ruby.go
@@ -378,7 +378,7 @@ func (r *rubyInstance) getStringCached(addr libpf.Address, reader StringReader) 
 		return libpf.NullString, err
 	}
 	if !util.IsValidString(str) {
-		log.Debugf("Extracted invalid string from Ruby at 0x%x '%v'", addr, libpf.SliceFrom(str))
+		log.Debugf("Extracted invalid string from Ruby at 0x%x '%v'", addr, []byte(str))
 		return libpf.NullString, fmt.Errorf("extracted invalid Ruby string from address 0x%x", addr)
 	}
 


### PR DESCRIPTION
libpf.SliceFrom expects a Slice or a Pointer and panics when given a string:

```
panic: invalid type

goroutine 111 [running]:
go.opentelemetry.io/ebpf-profiler/libpf.SliceFrom({0x2540780?, 0x4bacf40?})
	/home/runner/go/pkg/mod/github.com/!data!dog/opentelemetry-ebpf-profiler@v0.0.0-20250808130051-25ec00d52d7a/libpf/convenience.go:43 +0x205
go.opentelemetry.io/ebpf-profiler/interpreter/ruby.(*rubyInstance).getStringCached(0xc00293c380, 0x78721261fbf0, 0xc003a1bb08)
	/home/runner/go/pkg/mod/github.com/!data!dog/opentelemetry-ebpf-profiler@v0.0.0-20250808130051-25ec00d52d7a/interpreter/ruby/ruby.go:381 +0x10e
go.opentelemetry.io/ebpf-profiler/interpreter/ruby.(*rubyInstance).Symbolize(0xc00293c380, 0xc002bea480?, 0xc0023c8d80)
	/home/runner/go/pkg/mod/github.com/!data!dog/opentelemetry-ebpf-profiler@v0.0.0-20250808130051-25ec00d52d7a/interpreter/ruby/ruby.go:672 +0x1ff
go.opentelemetry.io/ebpf-profiler/processmanager.(*ProcessManager).symbolizeFrame(0xc0003c3e10, 0x1c, 0xc002f049c0, 0xc0023c8d80)
	/home/runner/go/pkg/mod/github.com/!data!dog/opentelemetry-ebpf-profiler@v0.0.0-20250808130051-25ec00d52d7a/processmanager/manager.go:203 +0x1d8
go.opentelemetry.io/ebpf-profiler/processmanager.(*ProcessManager).ConvertTrace(0xc0003c3e10, 0xc002f049c0)
	/home/runner/go/pkg/mod/github.com/!data!dog/opentelemetry-ebpf-profiler@v0.0.0-20250808130051-25ec00d52d7a/processmanager/manager.go:292 +0x558
go.opentelemetry.io/ebpf-profiler/tracehandler.(*traceHandler).HandleTrace(0xc002be6f00, 0xc002f049c0)
	/home/runner/go/pkg/mod/github.com/!data!dog/opentelemetry-ebpf-profiler@v0.0.0-20250808130051-25ec00d52d7a/tracehandler/tracehandler.go:153 +0x2ab
go.opentelemetry.io/ebpf-profiler/tracehandler.Start.func1()
	/home/runner/go/pkg/mod/github.com/!data!dog/opentelemetry-ebpf-profiler@v0.0.0-20250808130051-25ec00d52d7a/tracehandler/tracehandler.go:190 +0x173
created by go.opentelemetry.io/ebpf-profiler/tracehandler.Start in goroutine 1
	/home/runner/go/pkg/mod/github.com/!data!dog/opentelemetry-ebpf-profiler@v0.0.0-20250808130051-25ec00d52d7a/tracehandler/tracehandler.go:179 +0x179
```