### PR TITLE
fix: ensure concurrent accesses to ProcessManager.interpreters and ProcessManager.pidToProcessInfo maps are safe

### DIFF
--- a/processmanager/manager.go
+++ b/processmanager/manager.go
@@ -268,17 +268,16 @@ func (pm *ProcessManager) maybeNotifyAPMAgent(
 	rawTrace *host.Trace, umTraceHash libpf.TraceHash, count uint16,
 ) string {
 	pm.mu.RLock()
+	// Keeping the lock until end of the function is needed because inner map can be modified concurrently (by synchronizeMappings/newFrameMapping).
+	defer pm.mu.RUnlock()
 	pidInterp, ok := pm.interpreters[rawTrace.PID]
-	pm.mu.RUnlock()
 	if !ok {
 		return ""
 	}
-
 	var serviceName string
 	for _, mapping := range pidInterp {
 		if apm, ok := mapping.(*apmint.Instance); ok {
 			apm.NotifyAPMAgent(rawTrace.PID, rawTrace, umTraceHash, count)
-
 			if serviceName != "" {
 				log.Warnf("Overwriting APM service name from '%s' to '%s' for PID %d",
 					serviceName,
@@ -369,13 +368,14 @@ func (pm *ProcessManager) HandleTrace(bpfTrace *host.Trace) {
 	if cacheHit != 0 {
 		pm.frameCacheHit.Add(cacheHit)
 	}
-
+	pm.mu.RLock()
 	// Release resources that were used to symbolize this stack.
 	for _, instance := range pm.interpreters[pid] {
 		if err := instance.ReleaseResources(); err != nil {
 			log.Warnf("Failed to release resources for %d: %v", pid, err)
 		}
 	}
+	pm.mu.RUnlock()
 
 	trace.Hash = traceutil.HashTrace(trace)
 	meta.APMServiceName = pm.maybeNotifyAPMAgent(bpfTrace, trace.Hash, 1)

--- a/processmanager/processinfo.go
+++ b/processmanager/processinfo.go
@@ -352,11 +352,13 @@ func (pm *ProcessManager) newFrameMapping(pr process.Process, m *process.Mapping
 		return libpf.FrameMapping{}, err
 	}
 
+	pm.mu.Lock()
 	pm.assignLibcInfo(pr.PID(), ei.LibcInfo)
 	if ei.Data != nil {
 		bias := libpf.Address(m.Vaddr - elfSpaceVA)
 		pm.handleNewInterpreter(pr, bias, m.GetOnDiskFileIdentifier(), ei.Data)
 	}
+	pm.mu.Unlock()
 
 	return libpf.NewFrameMapping(libpf.FrameMappingData{
 		File:       info.mappingFile,
@@ -482,7 +484,9 @@ func (pm *ProcessManager) synchronizeMappings(pr process.Process,
 		numChanges += pm.processRemovedMapping(pid, m)
 	}
 	pm.pidPageToMappingInfoSize -= numChanges
+	pm.mu.Lock()
 	pm.processRemovedInterpreters(pid, interpretersValid)
+	pm.mu.Unlock()
 
 	// Add new mappings
 	numChanges = 0


### PR DESCRIPTION
Fixes:
1. Updated ProcessManager.newFrameMapping to wrap the calls to assignLibcInfo and handleNewInterpreter with a write lock.
2. Updated ProcessManager.maybeNotifyAPMAgent to keep the read lock until end of the function.
3. Updated ProcessManager.HandleTrace to acquire a read lock before releasing resources.
4. Updated ProcessManager.synchronizeMappings to wrap processRemovedInterpreters with a write lock.