### PR TITLE
fix: adjust Trace.Frames capacity to number of kernel/bpf frames

### DIFF
--- a/processmanager/manager.go
+++ b/processmanager/manager.go
@@ -321,7 +321,7 @@ func (pm *ProcessManager) HandleTrace(bpfTrace *host.Trace) {
 	pid := bpfTrace.PID
 	kernelFramesLen := len(bpfTrace.KernelFrames)
 	trace := &libpf.Trace{
-		Frames:       make(libpf.Frames, kernelFramesLen, 512),
+		Frames:       make(libpf.Frames, kernelFramesLen, kernelFramesLen+len(bpfTrace.Frames)),
 		CustomLabels: bpfTrace.CustomLabels,
 	}
 	copy(trace.Frames, bpfTrace.KernelFrames)

--- a/reporter/base_reporter.go
+++ b/reporter/base_reporter.go
@@ -6,7 +6,6 @@ package reporter // import "go.opentelemetry.io/ebpf-profiler/reporter"
 import (
 	"errors"
 	"fmt"
-	"slices"
 
 	"go.opentelemetry.io/ebpf-profiler/libpf"
 	"go.opentelemetry.io/ebpf-profiler/libpf/xsync"
@@ -89,7 +88,7 @@ func (b *baseReporter) ReportTraceEvent(trace *libpf.Trace, meta *samples.TraceE
 		return nil
 	}
 	(*eventsTree)[samples.ContainerID(containerID)][meta.Origin][key] = &samples.TraceEvents{
-		Frames:     slices.Clone(trace.Frames),
+		Frames:     trace.Frames,
 		Timestamps: []uint64{uint64(meta.Timestamp)},
 		OffTimes:   []int64{meta.OffTime},
 		EnvVars:    meta.EnvVars,


### PR DESCRIPTION
Fixed 512 frame capacity lead to a large increase in RSS because reporter keeps a reference on frame array.
Having the reporter clone the frames instead of keeping a reference would solve the memory increase, but that's still:
* heap allocation (array cannot be stack allocated because it escapes `HandleTrace` function):
```
escape(make(libpf.Frames, kernelFramesLen, kernelFramesLen + len(bpfTrace.Frames)) escapes to heap)optimizer details
manager.go(324, 21): escflow: flow: {storage for &libpf.Trace{...}} ← &{storage for make(libpf.Frames, kernelFramesLen, kernelFramesLen + len(bpfTrace.Frames))}:
manager.go(324, 21): escflow: from make(libpf.Frames, kernelFramesLen, kernelFramesLen + len(bpfTrace.Frames)) (spill)
manager.go(323, 23): escflow: from libpf.Trace{...} (struct literal element)
```
* heap allocation + copy in reporter clone

It's seems better to adjust the capacity to the number of kernel and bpf frames: symbolication might add some additional frames because of inlining, but it's uncommon. Hence it's a single heap allocation without copy.