### PR TITLE
reporter: compute profile duration based on profiler collection time

### DIFF
--- a/.github/workflows/env/action.yml
+++ b/.github/workflows/env/action.yml
@@ -20,21 +20,27 @@ runs:
       run: |
         # Ubuntu has ARM64 packages in an entirely different repo, so we can't just
         # `dpkg --add-architecture arm64` here: we have to add a custom sources.list first.
+        #
+        # We only need 'main' and 'universe' components (not restricted/multiverse)
+        # to minimize package index downloads.
         sudo tee /etc/apt/sources.list.d/ubuntu.sources <<EOF > /dev/null
         Types: deb
         URIs: http://azure.archive.ubuntu.com/ubuntu/
         Suites: noble noble-updates noble-backports
-        Components: main universe restricted multiverse
+        Components: main universe
         Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
         Architectures: amd64
 
         Types: deb
         URIs: http://azure.ports.ubuntu.com/ubuntu-ports/
         Suites: noble noble-updates noble-backports
-        Components: main universe restricted multiverse
+        Components: main universe
         Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
         Architectures: arm64
         EOF
+
+        # Skip downloading translations to speed up apt-get update
+        echo 'Acquire::Languages "none";' | sudo tee /etc/apt/apt.conf.d/99no-translations > /dev/null
 
         sudo dpkg --add-architecture arm64
         sudo apt-get update -y

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ go 1.24.0
 require (
 	github.com/aws/aws-sdk-go-v2 v1.41.1
 	github.com/aws/aws-sdk-go-v2/config v1.32.7
-	github.com/aws/aws-sdk-go-v2/service/s3 v1.95.1
+	github.com/aws/aws-sdk-go-v2/service/s3 v1.96.0
 	github.com/cilium/ebpf v0.20.0
 	github.com/elastic/go-freelru v0.16.0
 	github.com/elastic/go-perf v0.0.0-20241029065020-30bec95324b8

--- a/go.sum
+++ b/go.sum
@@ -24,8 +24,8 @@ github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.17 h1:RuNSMooz
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.17/go.mod h1:F2xxQ9TZz5gDWsclCtPQscGpP0VUOc8RqgFM3vDENmU=
 github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.17 h1:bGeHBsGZx0Dvu/eJC0Lh9adJa3M1xREcndxLNZlve2U=
 github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.17/go.mod h1:dcW24lbU0CzHusTE8LLHhRLI42ejmINN8Lcr22bwh/g=
-github.com/aws/aws-sdk-go-v2/service/s3 v1.95.1 h1:C2dUPSnEpy4voWFIq3JNd8gN0Y5vYGDo44eUE58a/p8=
-github.com/aws/aws-sdk-go-v2/service/s3 v1.95.1/go.mod h1:5jggDlZ2CLQhwJBiZJb4vfk4f0GxWdEDruWKEJ1xOdo=
+github.com/aws/aws-sdk-go-v2/service/s3 v1.96.0 h1:oeu8VPlOre74lBA/PMhxa5vewaMIMmILM+RraSyB8KA=
+github.com/aws/aws-sdk-go-v2/service/s3 v1.96.0/go.mod h1:5jggDlZ2CLQhwJBiZJb4vfk4f0GxWdEDruWKEJ1xOdo=
 github.com/aws/aws-sdk-go-v2/service/signin v1.0.5 h1:VrhDvQib/i0lxvr3zqlUwLwJP4fpmpyD9wYG1vfSu+Y=
 github.com/aws/aws-sdk-go-v2/service/signin v1.0.5/go.mod h1:k029+U8SY30/3/ras4G/Fnv/b88N4mAfliNn08Dem4M=
 github.com/aws/aws-sdk-go-v2/service/sso v1.30.9 h1:v6EiMvhEYBoHABfbGB4alOYmCIrcgyPPiBE1wZAEbqk=

--- a/interpreter/apmint/socket.go
+++ b/interpreter/apmint/socket.go
@@ -164,7 +164,7 @@ func parseUIDGIDLine(line string) (uint32, error) {
 	}
 
 	// Fields: real, effective, saved, FS UID
-	eid, err := strconv.Atoi(fields[2])
+	eid, err := strconv.ParseUint(fields[2], 10, 32)
 	if err != nil {
 		return 0, fmt.Errorf("failed to parse uid/gid int: %v", err)
 	}

--- a/interpreter/beam/beam.go
+++ b/interpreter/beam/beam.go
@@ -145,8 +145,8 @@ func Loader(ebpf interpreter.EbpfHandler, info *interpreter.LoaderInfo) (interpr
 		return nil, fmt.Errorf("failed to read OTP release: %v", err)
 	}
 	// Slice off the null-terminator before parsing
-	otpRelease, err := strconv.Atoi(string(otpReleaseString[:len(otpReleaseString)-1]))
-	if err != nil || otpRelease < 0 || otpRelease > 255 {
+	otpRelease, err := strconv.ParseUint(string(otpReleaseString[:len(otpReleaseString)-1]), 10, 32)
+	if err != nil || otpRelease > 255 {
 		return nil, fmt.Errorf("Invalid OTP Release: %v", otpReleaseString)
 	}
 

--- a/interpreter/dotnet/dotnet.go
+++ b/interpreter/dotnet/dotnet.go
@@ -144,9 +144,9 @@ func Loader(_ interpreter.EbpfHandler, info *interpreter.LoaderInfo) (interprete
 	if matches == nil {
 		return nil, nil
 	}
-	major, _ := strconv.Atoi(matches[1])
-	minor, _ := strconv.Atoi(matches[2])
-	release, _ := strconv.Atoi(matches[3])
+	major, _ := strconv.ParseUint(matches[1], 10, 32)
+	minor, _ := strconv.ParseUint(matches[2], 10, 32)
+	release, _ := strconv.ParseUint(matches[3], 10, 32)
 	version := dotnetVer(uint32(major), uint32(minor), uint32(release))
 
 	// dotnet8 requires additional support for RangeSectionMap and MethodDesc updates

--- a/interpreter/php/opcache.go
+++ b/interpreter/php/opcache.go
@@ -143,7 +143,7 @@ var (
 )
 
 type opcacheData struct {
-	version uint
+	version uint32
 
 	// dasmBuf is the address of the shared memory that is used for the JIT'd code.
 	// This is defined here:
@@ -252,7 +252,7 @@ func (d *opcacheData) Attach(_ interpreter.EbpfHandler, _ libpf.PID, bias libpf.
 func (d *opcacheData) Unload(_ interpreter.EbpfHandler) {
 }
 
-func determineOPCacheVersion(ef *pfelf.File) (uint, error) {
+func determineOPCacheVersion(ef *pfelf.File) (uint32, error) {
 	// In contrast to interpreterphp, the opcache actually contains
 	// a really straightforward way to recover the version. As the opcache
 	// is a Zend extension, it has to provide a version, which just so

--- a/interpreter/php/php.go
+++ b/interpreter/php/php.go
@@ -51,12 +51,12 @@ var (
 	_ interpreter.Instance = &phpInstance{}
 )
 
-func phpVersion(major, minor, release uint) uint {
+func phpVersion(major, minor, release uint32) uint32 {
 	return major*0x10000 + minor*0x100 + release
 }
 
 type phpData struct {
-	version uint
+	version uint32
 
 	// egAddr is the `executor_globals` symbol value which is needed by the eBPF
 	// program to build php backtraces.
@@ -146,19 +146,19 @@ func (d *phpData) Attach(ebpf interpreter.EbpfHandler, pid libpf.PID, bias libpf
 func (d *phpData) Unload(_ interpreter.EbpfHandler) {
 }
 
-func versionExtract(rodata string) (uint, error) {
+func versionExtract(rodata string) (uint32, error) {
 	matches := versionMatch.FindStringSubmatch(rodata)
 	if matches == nil {
 		return 0, errors.New("no valid PHP version string found")
 	}
 
-	major, _ := strconv.Atoi(matches[1])
-	minor, _ := strconv.Atoi(matches[2])
-	release, _ := strconv.Atoi(matches[3])
-	return phpVersion(uint(major), uint(minor), uint(release)), nil
+	major, _ := strconv.ParseUint(matches[1], 10, 32)
+	minor, _ := strconv.ParseUint(matches[2], 10, 32)
+	release, _ := strconv.ParseUint(matches[3], 10, 32)
+	return phpVersion(uint32(major), uint32(minor), uint32(release)), nil
 }
 
-func determinePHPVersion(ef *pfelf.File) (uint, error) {
+func determinePHPVersion(ef *pfelf.File) (uint32, error) {
 	// There is no ideal way to get the PHP version. This just searches
 	// for a known string with the version number from .rodata.
 	if ef.ROData == nil {

--- a/interpreter/php/php_test.go
+++ b/interpreter/php/php_test.go
@@ -30,7 +30,7 @@ func TestPHPRegexs(t *testing.T) {
 func TestVersionExtract(t *testing.T) {
 	tests := map[string]struct {
 		given       string
-		expected    uint
+		expected    uint32
 		expectError bool
 	}{
 		"7.x":          {given: "7.4.19", expected: phpVersion(7, 4, 19), expectError: false},

--- a/interpreter/python/python.go
+++ b/interpreter/python/python.go
@@ -44,8 +44,8 @@ var (
 )
 
 // pythonVer builds a version number from readable numbers
-func pythonVer(major, minor int) uint16 {
-	return uint16(major)*0x100 + uint16(minor)
+func pythonVer(major, minor uint16) uint16 {
+	return major*0x100 + minor
 }
 
 //nolint:lll
@@ -701,9 +701,9 @@ func Loader(ebpf interpreter.EbpfHandler, info *interpreter.LoaderInfo) (interpr
 	}
 
 	var pyruntimeAddr, autoTLSKey libpf.SymbolValue
-	major, _ := strconv.Atoi(matches[1])
-	minor, _ := strconv.Atoi(matches[2])
-	version := pythonVer(major, minor)
+	major, _ := strconv.ParseUint(matches[1], 10, 16)
+	minor, _ := strconv.ParseUint(matches[2], 10, 16)
+	version := pythonVer(uint16(major), uint16(minor))
 
 	minVer := pythonVer(3, 6)
 	maxVer := pythonVer(3, 14)

--- a/interpreter/ruby/ruby.go
+++ b/interpreter/ruby/ruby.go
@@ -1233,9 +1233,9 @@ func determineRubyVersion(ef *pfelf.File) (uint32, error) {
 	if len(matches) < 3 {
 		return 0, fmt.Errorf("failed to parse version string: '%s'", versionString)
 	}
-	major, _ := strconv.Atoi(matches[1])
-	minor, _ := strconv.Atoi(matches[2])
-	release, _ := strconv.Atoi(matches[3])
+	major, _ := strconv.ParseUint(matches[1], 10, 32)
+	minor, _ := strconv.ParseUint(matches[2], 10, 32)
+	release, _ := strconv.ParseUint(matches[3], 10, 32)
 
 	return rubyVersion(uint32(major), uint32(minor), uint32(release)), nil
 }

--- a/libpf/convenience.go
+++ b/libpf/convenience.go
@@ -17,5 +17,11 @@ func AddJitter(baseDuration time.Duration, jitter float64) time.Duration {
 		return baseDuration
 	}
 	//nolint:gosec
-	return time.Duration((1 + jitter - 2*jitter*rand.Float64()) * float64(baseDuration))
+	result := time.Duration((1 + jitter - 2*jitter*rand.Float64()) * float64(baseDuration))
+	// Clamp to baseDuration to prevent panic in time.Ticker.Reset with d <= 0.
+	// With jitter close to 1.0, float arithmetic can produce values that truncate to 0.
+	if result < 1 {
+		return baseDuration
+	}
+	return result
 }

--- a/reporter/base_reporter.go
+++ b/reporter/base_reporter.go
@@ -6,6 +6,7 @@ package reporter // import "go.opentelemetry.io/ebpf-profiler/reporter"
 import (
 	"errors"
 	"fmt"
+	"time"
 
 	"go.opentelemetry.io/ebpf-profiler/libpf"
 	"go.opentelemetry.io/ebpf-profiler/libpf/xsync"
@@ -32,6 +33,11 @@ type baseReporter struct {
 
 	// traceEvents stores reported trace events (trace metadata with frames and counts)
 	traceEvents xsync.RWMutex[samples.TraceEventsTree]
+
+	// collectionStartTime tracks when the current collection window started.
+	// Initialized when Start() is called. The duration of the first profile may be
+	// slightly overestimated as it includes tracer setup time before samples arrive.
+	collectionStartTime time.Time
 }
 
 var errUnknownOrigin = errors.New("unknown trace origin")

--- a/reporter/collector_reporter.go
+++ b/reporter/collector_reporter.go
@@ -5,6 +5,7 @@ package reporter // import "go.opentelemetry.io/ebpf-profiler/reporter"
 
 import (
 	"context"
+	"time"
 
 	"go.opentelemetry.io/collector/consumer/xconsumer"
 	"go.opentelemetry.io/ebpf-profiler/internal/log"
@@ -53,6 +54,9 @@ func NewCollector(cfg *Config, nextConsumer xconsumer.Profiles) (*CollectorRepor
 }
 
 func (r *CollectorReporter) Start(ctx context.Context) error {
+	// Initialize collection start time
+	r.collectionStartTime = time.Now()
+
 	// Create a child context for reporting features
 	ctx, cancelReporting := context.WithCancel(ctx)
 
@@ -82,9 +86,13 @@ func (r *CollectorReporter) reportProfile(ctx context.Context) error {
 	reportedEvents := (*traceEventsPtr)
 	newEvents := make(samples.TraceEventsTree)
 	*traceEventsPtr = newEvents
+	collectionEndTime := time.Now()
+	collectionStartTime := r.collectionStartTime
+	r.collectionStartTime = collectionEndTime
 	r.traceEvents.WUnlock(&traceEventsPtr)
 
-	profiles, err := r.pdata.Generate(reportedEvents, r.name, r.version)
+	profiles, err := r.pdata.Generate(reportedEvents, r.name, r.version,
+		collectionStartTime, collectionEndTime)
 	if err != nil {
 		log.Errorf("pdata: %v", err)
 		return nil

--- a/reporter/collector_reporter.go
+++ b/reporter/collector_reporter.go
@@ -54,7 +54,6 @@ func NewCollector(cfg *Config, nextConsumer xconsumer.Profiles) (*CollectorRepor
 }
 
 func (r *CollectorReporter) Start(ctx context.Context) error {
-	// Initialize collection start time
 	r.collectionStartTime = time.Now()
 
 	// Create a child context for reporting features

--- a/reporter/otlp_reporter.go
+++ b/reporter/otlp_reporter.go
@@ -71,6 +71,9 @@ func NewOTLP(cfg *Config) (*OTLPReporter, error) {
 
 // Start sets up and manages the reporting connection to a OTLP backend.
 func (r *OTLPReporter) Start(ctx context.Context) error {
+	// Initialize collection start time
+	r.collectionStartTime = time.Now()
+
 	// Create a child context for reporting features
 	ctx, cancelReporting := context.WithCancel(ctx)
 
@@ -114,9 +117,13 @@ func (r *OTLPReporter) reportOTLPProfile(ctx context.Context) error {
 	reportedEvents := (*traceEventsPtr)
 	newEvents := make(samples.TraceEventsTree)
 	*traceEventsPtr = newEvents
+	collectionEndTime := time.Now()
+	collectionStartTime := r.collectionStartTime
+	r.collectionStartTime = collectionEndTime
 	r.traceEvents.WUnlock(&traceEventsPtr)
 
-	profiles, err := r.pdata.Generate(reportedEvents, r.name, r.version)
+	profiles, err := r.pdata.Generate(reportedEvents, r.name, r.version,
+		collectionStartTime, collectionEndTime)
 	if err != nil {
 		log.Errorf("pdata: %v", err)
 		return nil

--- a/reporter/otlp_reporter.go
+++ b/reporter/otlp_reporter.go
@@ -71,7 +71,6 @@ func NewOTLP(cfg *Config) (*OTLPReporter, error) {
 
 // Start sets up and manages the reporting connection to a OTLP backend.
 func (r *OTLPReporter) Start(ctx context.Context) error {
-	// Initialize collection start time
 	r.collectionStartTime = time.Now()
 
 	// Create a child context for reporting features

--- a/tracer/types/parse.go
+++ b/tracer/types/parse.go
@@ -161,9 +161,6 @@ func Parse(tracers string) (IncludedTracers, error) {
 		switch name {
 		case "all":
 			result.enableAll()
-			if runtime.GOARCH == "arm64" {
-				result.Disable(DotnetTracer)
-			}
 		case "native":
 			log.Warn("Enabling the `native` tracer explicitly is deprecated (it's always-on)")
 		default:


### PR DESCRIPTION
previously, we were reporting the profile duration based on sampled
events for specific resources. this means that idle resources could end
up with much smaller profile durations that would not reflect the actual
utilization, compared to busy resources.

more generally, using the sample timestamps to compute the duration
leads to very small duration for idle hosts, which would be inaccurate
if the profile is running for much longer.

this change proposes setting the duration to the time during which the
profiler was running / collecting samples rather than samples timestamp.