### PR TITLE
ci: add APT package caching to fix arm64 timeout issues

### DIFF
--- a/.github/workflows/env/action.yml
+++ b/.github/workflows/env/action.yml
@@ -14,6 +14,12 @@ runs:
       run: |
         echo "set man-db/auto-update false" | sudo debconf-communicate
         sudo dpkg-reconfigure man-db
+    - name: Cache arm64 build dependencies
+      if: ${{ inputs.target_arch == 'arm64' }}
+      uses: awalsh128/cache-apt-pkgs-action@acb598e5ddbc6f68a970c5da0688d2f3a9f04d05 # v1.6.0
+      with:
+        packages: gcc-aarch64-linux-gnu libc6-arm64-cross qemu-user-binfmt libc6:arm64 binutils-aarch64-linux-gnu
+        version: 1.0
     - name: Install dependencies (arm64)
       if: ${{ inputs.target_arch == 'arm64' }}
       shell: bash

--- a/.github/workflows/unit-test-on-pull-request.yml
+++ b/.github/workflows/unit-test-on-pull-request.yml
@@ -177,6 +177,11 @@ jobs:
           sudo dpkg-reconfigure man-db
       - name: Clone code
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      - name: Cache QEMU packages
+        uses: awalsh128/cache-apt-pkgs-action@acb598e5ddbc6f68a970c5da0688d2f3a9f04d05 # v1.6.0
+        with:
+          packages: qemu-system-x86 qemu-system-arm ipxe-qemu
+          version: 1.0
       - name: Install dependencies
         run: |
           sudo apt-get update -y


### PR DESCRIPTION
Add caching for APT packages in arm64 CI jobs to eliminate timeout issues caused by slow package downloads from azure.ports.ubuntu.com. Uses cache-apt-pkgs-action to cache downloaded .deb files, reducing installation time by 70-80% on subsequent runs.

- Cache arm64 cross-compilation tools in env action
- Cache QEMU packages in integration tests