### PR TITLE
reporter: compute profile duration using the time during which the profiler was collecting samples 

### DIFF
--- a/reporter/base_reporter.go
+++ b/reporter/base_reporter.go
@@ -6,6 +6,7 @@ package reporter // import "go.opentelemetry.io/ebpf-profiler/reporter"
 import (
 	"errors"
 	"fmt"
+	"time"
 
 	"go.opentelemetry.io/ebpf-profiler/libpf"
 	"go.opentelemetry.io/ebpf-profiler/libpf/xsync"
@@ -32,6 +33,11 @@ type baseReporter struct {
 
 	// traceEvents stores reported trace events (trace metadata with frames and counts)
 	traceEvents xsync.RWMutex[samples.TraceEventsTree]
+
+	// collectionStartTime tracks when the current collection window started.
+	// Initialized when Start() is called. The duration of the first profile may be
+	// slightly overestimated as it includes tracer setup time before samples arrive.
+	collectionStartTime time.Time
 }
 
 var errUnknownOrigin = errors.New("unknown trace origin")

--- a/reporter/collector_reporter.go
+++ b/reporter/collector_reporter.go
@@ -5,6 +5,7 @@ package reporter // import "go.opentelemetry.io/ebpf-profiler/reporter"
 
 import (
 	"context"
+	"time"
 
 	"go.opentelemetry.io/collector/consumer/xconsumer"
 	"go.opentelemetry.io/ebpf-profiler/internal/log"
@@ -53,6 +54,8 @@ func NewCollector(cfg *Config, nextConsumer xconsumer.Profiles) (*CollectorRepor
 }
 
 func (r *CollectorReporter) Start(ctx context.Context) error {
+	r.collectionStartTime = time.Now()
+
 	// Create a child context for reporting features
 	ctx, cancelReporting := context.WithCancel(ctx)
 
@@ -82,9 +85,13 @@ func (r *CollectorReporter) reportProfile(ctx context.Context) error {
 	reportedEvents := (*traceEventsPtr)
 	newEvents := make(samples.TraceEventsTree)
 	*traceEventsPtr = newEvents
+	collectionEndTime := time.Now()
+	collectionStartTime := r.collectionStartTime
+	r.collectionStartTime = collectionEndTime
 	r.traceEvents.WUnlock(&traceEventsPtr)
 
-	profiles, err := r.pdata.Generate(reportedEvents, r.name, r.version)
+	profiles, err := r.pdata.Generate(reportedEvents, r.name, r.version,
+		collectionStartTime, collectionEndTime)
 	if err != nil {
 		log.Errorf("pdata: %v", err)
 		return nil

--- a/reporter/internal/pdata/generate.go
+++ b/reporter/internal/pdata/generate.go
@@ -5,7 +5,6 @@ package pdata // import "go.opentelemetry.io/ebpf-profiler/reporter/internal/pda
 
 import (
 	"fmt"
-	"math"
 	"path/filepath"
 	"time"
 
@@ -27,12 +26,34 @@ const (
 )
 
 // Generate generates a pdata request out of internal profiles data, to be
-// exported.
+// exported. The collectionStartTime and collectionEndTime define the time window
+// during which the profiler was actively collecting samples.
 func (p *Pdata) Generate(tree samples.TraceEventsTree,
 	agentName, agentVersion string,
+	collectionStartTime, collectionEndTime time.Time,
 ) (pprofile.Profiles, error) {
 	profiles := pprofile.NewProfiles()
 	dic := profiles.Dictionary()
+
+	// Find oldest sample timestamp across all containers to handle buffered samples.
+	adjustedStartTime := collectionStartTime
+	for _, containerEvents := range tree {
+		for _, originEvents := range containerEvents {
+			for _, traceEvents := range originEvents {
+				for _, ts := range traceEvents.Timestamps {
+					sampleTime := time.Unix(0, int64(ts))
+					if sampleTime.Before(adjustedStartTime) {
+						adjustedStartTime = sampleTime
+					}
+				}
+			}
+		}
+	}
+	if adjustedStartTime.Before(collectionStartTime) {
+		log.Debugf("Adjusted profile start time backward by %v to include oldest sample",
+			collectionStartTime.Sub(adjustedStartTime))
+	}
+	collectionStartTime = adjustedStartTime
 
 	// Temporary helpers that will build the various tables in ProfilesDictionary.
 	stringSet := make(orderedset.OrderedSet[string], 64)
@@ -84,7 +105,8 @@ func (p *Pdata) Generate(tree samples.TraceEventsTree,
 			prof := sp.Profiles().AppendEmpty()
 			if err := p.setProfile(dic,
 				attrMgr, stringSet, funcSet, mappingSet, stackSet, locationSet,
-				origin, originToEvents[origin], prof); err != nil {
+				origin, originToEvents[origin], prof,
+				collectionStartTime, collectionEndTime); err != nil {
 				return profiles, err
 			}
 		}
@@ -124,6 +146,7 @@ func (p *Pdata) setProfile(
 	origin libpf.Origin,
 	events map[samples.TraceAndMetaKey]*samples.TraceEvents,
 	profile pprofile.Profile,
+	collectionStartTime, collectionEndTime time.Time,
 ) error {
 	st := profile.SampleType()
 	switch origin {
@@ -146,14 +169,8 @@ func (p *Pdata) setProfile(
 		return fmt.Errorf("generating profile for unsupported origin %d", origin)
 	}
 
-	startTS, endTS := uint64(math.MaxUint64), uint64(0)
 	for traceKey, traceInfo := range events {
 		sample := profile.Samples().AppendEmpty()
-
-		for _, ts := range traceInfo.Timestamps {
-			startTS = min(startTS, ts)
-			endTS = max(endTS, ts)
-		}
 
 		sample.TimestampsUnixNano().FromRaw(traceInfo.Timestamps)
 		if origin == support.TraceOriginOffCPU {
@@ -280,8 +297,8 @@ func (p *Pdata) setProfile(
 
 	log.Debugf("Reporting OTLP profile with %d samples", profile.Samples().Len())
 
-	profile.SetDurationNano(endTS - startTS)
-	profile.SetTime(pcommon.Timestamp(startTS))
+	profile.SetDurationNano(uint64(collectionEndTime.Sub(collectionStartTime).Nanoseconds()))
+	profile.SetTime(pcommon.Timestamp(collectionStartTime.UnixNano()))
 
 	return nil
 }

--- a/reporter/otlp_reporter.go
+++ b/reporter/otlp_reporter.go
@@ -71,6 +71,8 @@ func NewOTLP(cfg *Config) (*OTLPReporter, error) {
 
 // Start sets up and manages the reporting connection to a OTLP backend.
 func (r *OTLPReporter) Start(ctx context.Context) error {
+	r.collectionStartTime = time.Now()
+
 	// Create a child context for reporting features
 	ctx, cancelReporting := context.WithCancel(ctx)
 
@@ -114,9 +116,13 @@ func (r *OTLPReporter) reportOTLPProfile(ctx context.Context) error {
 	reportedEvents := (*traceEventsPtr)
 	newEvents := make(samples.TraceEventsTree)
 	*traceEventsPtr = newEvents
+	collectionEndTime := time.Now()
+	collectionStartTime := r.collectionStartTime
+	r.collectionStartTime = collectionEndTime
 	r.traceEvents.WUnlock(&traceEventsPtr)
 
-	profiles, err := r.pdata.Generate(reportedEvents, r.name, r.version)
+	profiles, err := r.pdata.Generate(reportedEvents, r.name, r.version,
+		collectionStartTime, collectionEndTime)
 	if err != nil {
 		log.Errorf("pdata: %v", err)
 		return nil


### PR DESCRIPTION
## Summary
- Cherry-pick of upstream commit 38713478ab7ca3d80d0316c2c606fc21e7538d5b
- Computes profile duration using the time during which the profiler was actively collecting samples rather than a fixed interval