### PR TITLE
[PROF-13837] fix: resolve concurrent hotspotInstance.stubs map access

### DIFF
--- a/interpreter/hotspot/data.go
+++ b/interpreter/hotspot/data.go
@@ -379,7 +379,7 @@ func (d *hotspotData) Attach(_ interpreter.EbpfHandler, _ libpf.PID, bias libpf.
 		addrToJITInfo:  addrToJITInfo,
 		addrToStubName: addrToStubName,
 		prefixes:       libpf.Set[lpm.Prefix]{},
-		stubs:          map[libpf.Address]StubRoutine{},
+		stubs:          xsync.NewRWMutex(map[libpf.Address]StubRoutine{}),
 	}, nil
 }
 

--- a/interpreter/hotspot/instance.go
+++ b/interpreter/hotspot/instance.go
@@ -796,16 +796,17 @@ func (d *hotspotInstance) populateMainMappings(vmd *hotspotVMData,
 func (d *hotspotInstance) updateStubMappings(vmd *hotspotVMData,
 	ebpf interpreter.EbpfHandler, pid libpf.PID,
 ) {
-	for _, stub := range findStubBounds(vmd, d.bias, d.rm) {
-		stubs := d.stubs.WLock()
-		_, exists := (*stubs)[stub.start]
-		if !exists {
-			(*stubs)[stub.start] = stub
-		}
-		d.stubs.WUnlock(&stubs)
-		if exists {
+	allStubs := findStubBounds(vmd, d.bias, d.rm)
+
+	stubs := d.stubs.WLock()
+	defer d.stubs.WUnlock(&stubs)
+
+	for _, stub := range allStubs {
+		if _, exists := (*stubs)[stub.start]; exists {
 			continue
 		}
+
+		(*stubs)[stub.start] = stub
 
 		// Separate stub areas are only required on ARM64.
 		if runtime.GOARCH != "arm64" {

--- a/interpreter/hotspot/instance_test.go
+++ b/interpreter/hotspot/instance_test.go
@@ -6,14 +6,14 @@ package hotspot
 import (
 	"bytes"
 	"encoding/binary"
+	"fmt"
 	"strings"
+	"sync"
 	"testing"
 
-	"github.com/elastic/go-freelru"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/ebpf-profiler/libpf"
-	"go.opentelemetry.io/ebpf-profiler/lpm"
 	"go.opentelemetry.io/ebpf-profiler/remotememory"
 )
 
@@ -31,16 +31,9 @@ func TestJavaSymbolExtraction(t *testing.T) {
 	rd := bytes.NewReader(sym)
 	rm := remotememory.RemoteMemory{ReaderAt: rd}
 
-	addrToSymbol, err := freelru.New[libpf.Address, libpf.String](2, libpf.Address.Hash32)
+	instance, err := id.Attach(nil, 0, 0, rm)
 	require.NoError(t, err, "symbol cache failed")
-
-	ii := hotspotInstance{
-		d:            &id,
-		rm:           rm,
-		addrToSymbol: addrToSymbol,
-		prefixes:     libpf.Set[lpm.Prefix]{},
-		stubs:        map[libpf.Address]StubRoutine{},
-	}
+	ii := instance.(*hotspotInstance)
 
 	str := strings.Repeat("a", maxLength)
 	copy(sym[vmd.vmStructs.Symbol.Body:], str)
@@ -50,4 +43,78 @@ func TestJavaSymbolExtraction(t *testing.T) {
 		assert.Equal(t, str[:i], got.String(), "symbol length %d mismatched read", i)
 		ii.addrToSymbol.Purge()
 	}
+}
+
+// TestStubsMapRace verifies there is no data race on concurrent
+// read and write access to d.stubs.
+func TestStubsMapRace(t *testing.T) {
+	const (
+		fieldName      = 0
+		fieldCodeBegin = 8
+	)
+
+	const (
+		codeBeginAddr = 0x1000
+		numStubs      = 50
+		stubSpacing   = 128
+		// based on value defined in findStubBounds() in stubs.go
+		maxStubLen = 8 * 1024
+		blobName   = "StubCode"
+	)
+
+	const (
+		slotsBase  = 16
+		slotsEnd   = slotsBase + numStubs*8
+		nameBase   = slotsEnd
+		codeBase   = 1024
+		bufSize    = codeBase + numStubs*stubSpacing + maxStubLen
+		iterations = 500
+	)
+
+	buf := make([]byte, bufSize)
+	binary.LittleEndian.PutUint64(buf[fieldName:], nameBase)
+	binary.LittleEndian.PutUint64(buf[fieldCodeBegin:], codeBeginAddr)
+	copy(buf[nameBase:], blobName)
+
+	catchAll := make(map[string]libpf.Address, numStubs)
+	for i := range numStubs {
+		slot := libpf.Address(slotsBase + i*8)
+		stubAddr := uint64(codeBase + i*stubSpacing)
+		binary.LittleEndian.PutUint64(buf[slot:], stubAddr)
+		catchAll[fmt.Sprintf("_stub_%d", i)] = slot
+	}
+
+	rd := bytes.NewReader(buf)
+	rm := remotememory.RemoteMemory{ReaderAt: rd}
+
+	id := hotspotData{}
+	vmd, _ := id.GetOrInit(func() (hotspotVMData, error) {
+		vmd := hotspotVMData{}
+		vmd.vmStructs.CodeBlob.Name = fieldName
+		vmd.vmStructs.CodeBlob.CodeBegin = fieldCodeBegin
+		vmd.vmStructs.StubRoutines.CatchAll = catchAll
+		return vmd, nil
+	})
+
+	instance, err := id.Attach(nil, 0, 0, rm)
+	require.NoError(t, err)
+	ii := instance.(*hotspotInstance)
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for range iterations {
+			ii.updateStubMappings(vmd, nil, 0)
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for range iterations {
+			ii.addrToStubName.Purge()
+			ii.getStubName(0, 0)
+		}
+	}()
+
+	wg.Wait()
 }


### PR DESCRIPTION
### What does this PR do?

This PR introduces a mutex to protect the `hotspotInstance.stubs` map from concurrent access.

### Motivation

We observed a panic caused by a concurrent map read and write on the stubs map.
```
fatal error: concurrent map iteration and map write

goroutine 301 [running]:
internal/runtime/maps.fatal({0x532cbcf?, 0xc000538d40?})
	runtime/panic.go:1046 +0x18
internal/runtime/maps.(*Iter).Next(0xc001935a20?)
	internal/runtime/maps/table.go:792 +0x86
go.opentelemetry.io/ebpf-profiler/interpreter/hotspot.(*hotspotInstance).getStubName(0xc0016e39e0, 0xc9, 0x75f0e4737b90)
	go.opentelemetry.io/ebpf-profiler@v0.0.202547/interpreter/hotspot/instance.go:245 +0x147
go.opentelemetry.io/ebpf-profiler/interpreter/hotspot.(*hotspotInstance).Symbolize(0x4b1bb20?, 0xc0017c7ef0?, 0xc004283680)
	go.opentelemetry.io/ebpf-profiler@v0.0.202547/interpreter/hotspot/instance.go:889 +0x227
go.opentelemetry.io/ebpf-profiler/processmanager.(*ProcessManager).symbolizeFrame(0xc000001420, 0xe4945, 0xc0026f2fc0, 0xc004283680)
	go.opentelemetry.io/ebpf-profiler@v0.0.202547/processmanager/manager.go:190 +0x18b
go.opentelemetry.io/ebpf-profiler/processmanager.(*ProcessManager).convertFrame(0xc002852750?, 0xe4945, 0xc0026f2fc0, 0xc004283680)
	go.opentelemetry.io/ebpf-profiler@v0.0.202547/processmanager/manager.go:247 +0xc5
go.opentelemetry.io/ebpf-profiler/processmanager.(*ProcessManager).HandleTrace(0xc000001420, 0xc0038aaaa0)
	go.opentelemetry.io/ebpf-profiler@v0.0.202547/processmanager/manager.go:351 +0x5b0
go.opentelemetry.io/ebpf-profiler/tracer.(*Tracer).HandleTrace(...)
	go.opentelemetry.io/ebpf-profiler@v0.0.202547/tracer/tracer.go:1207
go.opentelemetry.io/ebpf-profiler/internal/controller.startTraceHandling.func1()
	go.opentelemetry.io/ebpf-profiler@v0.0.202547/internal/controller/controller.go:178 +0xb7
created by go.opentelemetry.io/ebpf-profiler/internal/controller.startTraceHandling in goroutine 1
	go.opentelemetry.io/ebpf-profiler@v0.0.202547/internal/controller/controller.go:172 +0xf9
```

### Describe how you validated your changes

- Added a regression test to ensure the race condition no longer exists.
- Validated this behavior using the Go -race flag.

### Additional Notes