### PR TITLE
[PROF-13913] Ensure opentelemetry-ebpf-profiler support for JDK 26

### DIFF
--- a/.github/chainguard/self.prepare-rebase-on-upstream.create-pr.sts.yaml
+++ b/.github/chainguard/self.prepare-rebase-on-upstream.create-pr.sts.yaml
@@ -1,0 +1,12 @@
+issuer: https://token.actions.githubusercontent.com
+
+subject: repo:DataDog/opentelemetry-ebpf-profiler:ref:refs/heads/datadog
+
+claim_pattern:
+  event_name: workflow_dispatch
+  ref: refs/heads/datadog
+  ref_protected: "true"
+  job_workflow_ref: DataDog/opentelemetry-ebpf-profiler/.github/workflows/prepare-rebase-on-upstream.yml@refs/heads/datadog
+
+permissions:
+  pull_requests: write

--- a/.github/workflows/prepare-rebase-on-upstream.yml
+++ b/.github/workflows/prepare-rebase-on-upstream.yml
@@ -1,0 +1,53 @@
+name: Prepare rebase on upstream
+on:
+  workflow_dispatch:
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ssh-key: ${{ secrets.DEPLOY_KEY }}
+
+      - name: Set up Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      # Do not use `gh repo sync` with GITHUB_TOKEN, it will fail with 422:
+      # {"message":"Repository rule violations found","documentation_url":"https://docs.github.com/rest/branches/branches#sync-a-fork-branch-with-the-upstream-repository","status":"422"}
+      - name: Sync main with upstream
+        run: |
+          git switch main
+          git remote add upstream git@github.com:open-telemetry/opentelemetry-ebpf-profiler.git
+          git fetch upstream
+          git merge --ff upstream/main
+          git push origin
+
+      - name: Checkout datadog branch
+        run: |
+          git switch datadog
+          git pull
+
+      - name: Rebase datadog on main
+        run: |
+          git switch -c rebase-on-upstream
+          git rebase origin/main
+          git push origin rebase-on-upstream
+
+      - name: Create PR
+        run: |
+          gh pr create -R ${{ github.repository }} --base main --head rebase-on-upstream --title "Rebase datadog on upstream/main" --body "This PR is to rebase datadog branch on main branch"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Add comment
+        run: |
+          gh pr comment rebase-on-upstream -R ${{ github.repository }} --body "Please close and re-open this PR to trigger the tests."
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/prepare-rebase-on-upstream.yml
+++ b/.github/workflows/prepare-rebase-on-upstream.yml
@@ -6,8 +6,13 @@ jobs:
   prepare:
     runs-on: ubuntu-latest
     permissions:
-      pull-requests: write
+      id-token: write # Needed to federate tokens
     steps:
+      - uses: DataDog/dd-octo-sts-action@acaa02eee7e3bb0839e4272dacb37b8f3b58ba80 # v1.0.3
+        id: octo-sts
+        with:
+          scope: open-telemetry/opentelemetry-ebpf-profiler
+          policy: self.prepare-rebase-on-upstream.create-pr
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
@@ -44,10 +49,10 @@ jobs:
         run: |
           gh pr create -R ${{ github.repository }} --base main --head rebase-on-upstream --title "Rebase datadog on upstream/main" --body "This PR is to rebase datadog branch on main branch"
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
 
       - name: Add comment
         run: |
           gh pr comment rebase-on-upstream -R ${{ github.repository }} --body "Please close and re-open this PR to trigger the tests."
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.octo-sts.outputs.token }}

--- a/.github/workflows/prepare-rebase-on-upstream.yml
+++ b/.github/workflows/prepare-rebase-on-upstream.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: DataDog/dd-octo-sts-action@acaa02eee7e3bb0839e4272dacb37b8f3b58ba80 # v1.0.3
         id: octo-sts
         with:
-          scope: open-telemetry/opentelemetry-ebpf-profiler
+          scope: DataDog/opentelemetry-ebpf-profiler
           policy: self.prepare-rebase-on-upstream.create-pr
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/rebase-on-upstream.yml
+++ b/.github/workflows/rebase-on-upstream.yml
@@ -1,0 +1,79 @@
+name: Rebase on upstream
+
+on:
+  workflow_dispatch:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ssh-key: ${{ secrets.DEPLOY_KEY }}
+
+      - name: Set up Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Check PR
+        id: check_pr
+        run: |
+          # Check that ${{ github.ref_name }} has main as ancestor (ie. fast forward merge is possible)
+          if ! git merge-base --is-ancestor origin/main ${{ github.ref_name }}; then
+            echo "${{ github.ref_name }} does not have main as ancestor"
+            exit 1
+          fi
+
+          gh pr list --state open --head ${{ github.ref_name }} --base main --json number,reviewDecision,state,isDraft,mergeable,statusCheckRollup > pr.json
+          # Check that there is a single PR with main as base branch and ${{ github.ref_name }} as head branch
+          if [[ "$(jq length pr.json)" -eq 0 ]]; then
+            echo "No PR with main as base branch and ${{ github.ref_name }} as head branch"
+            exit 1
+          fi
+          # No need to check that PR count is greater than 1, because github prevents creating multiple PRs with the same head and base branches
+
+          # Check that PR is not draft
+          if [[ "$(jq '.[0] | .isDraft' pr.json)" == "true" ]]; then
+            echo "PR is a draft"
+            exit 1
+          fi
+
+          # Check that PR is mergeable
+          if [[ "$(jq '.[0] | .mergeable' pr.json)" == "false" ]]; then
+            echo "PR is not mergeable"
+            exit 1
+          fi
+
+          # Check that PR is approved
+          if [[ "$(jq -r '.[0] | .reviewDecision' pr.json)" != "APPROVED" ]]; then
+            echo "PR is not approved"
+            exit 1
+          fi
+
+          # Check that PR build is successful, sdm policy check is a bit different from the others
+          unsuccessful_check_count=$(jq '[.[0] | .statusCheckRollup | .[] | select(.workflowName != null and (.status != "COMPLETED" or .conclusion != "SUCCESS") or (.context != null and .state != "SUCCESS"))] | length' pr.json)
+          if [[ "$unsuccessful_check_count" -gt 0 ]]; then
+            echo "PR build is not successful"
+            exit 1
+          fi
+
+          echo "pr_number=$(jq '.[0] | .number' pr.json)" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Rewrite datadog branch
+        run: |
+          git checkout datadog
+          git reset --hard ${{ github.ref_name }}
+          git push -f
+
+      - name: Close PR and delete update branch
+        run: |
+          gh pr close -d ${{ steps.check_pr.outputs.pr_number }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/rebase-on-upstream.yml
+++ b/.github/workflows/rebase-on-upstream.yml
@@ -8,6 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
+      contents: write # need this permission to delete update branch
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/rebase-on-upstream.yml
+++ b/.github/workflows/rebase-on-upstream.yml
@@ -57,7 +57,7 @@ jobs:
           fi
 
           # Check that PR build is successful, sdm policy check is a bit different from the others
-          unsuccessful_check_count=$(jq '[.[0] | .statusCheckRollup | .[] | select(.workflowName != null and (.status != "COMPLETED" or .conclusion != "SUCCESS") or (.context != null and .state != "SUCCESS"))] | length' pr.json)
+          unsuccessful_check_count=$(jq '[.[0] | .statusCheckRollup | .[] | select(.workflowName != null and (.status != "COMPLETED" or (.conclusion != "SUCCESS" and .conclusion != "SKIPPED")) or (.context != null and .state != "SUCCESS"))] | length' pr.json)
           if [[ "$unsuccessful_check_count" -gt 0 ]]; then
             echo "PR build is not successful"
             exit 1

--- a/cli_flags.go
+++ b/cli_flags.go
@@ -20,6 +20,7 @@ const (
 	// Default values for CLI flags
 	defaultArgSamplesPerSecond    = 20
 	defaultArgReporterInterval    = 5.0 * time.Second
+	defaultArgReporterJitter      = 0.2
 	defaultArgMonitorInterval     = 5.0 * time.Second
 	defaultClockSyncInterval      = 3 * time.Minute
 	defaultProbabilisticThreshold = tracer.ProbabilisticThresholdMax
@@ -56,9 +57,13 @@ var (
 		tracer.ProbabilisticThresholdMax-1, tracer.ProbabilisticThresholdMax-1)
 	probabilisticIntervalHelp = "Time interval for which probabilistic profiling will be " +
 		"enabled or disabled."
-	pprofHelp             = "Listening address (e.g. localhost:6060) to serve pprof information."
-	samplesPerSecondHelp  = "Set the frequency (in Hz) of stack trace sampling."
-	reporterIntervalHelp  = "Set the reporter's interval in seconds."
+	pprofHelp            = "Listening address (e.g. localhost:6060) to serve pprof information."
+	samplesPerSecondHelp = "Set the frequency (in Hz) of stack trace sampling."
+	reporterIntervalHelp = "Set the reporter's interval in seconds."
+	reporterJitterHelp   = fmt.Sprintf("Set the jitter applied to the reporter's interval as a fraction. "+
+		"Valid values are in the range [0..1]. "+
+		"Default is %.1f.",
+		defaultArgReporterJitter)
 	monitorIntervalHelp   = "Set the monitor interval in seconds."
 	clockSyncIntervalHelp = "Set the sync interval with the realtime clock. " +
 		"If zero, monotonic-realtime clock sync will be performed once, " +
@@ -114,6 +119,8 @@ func parseArgs() (*controller.Config, error) {
 
 	fs.DurationVar(&args.ReporterInterval, "reporter-interval", defaultArgReporterInterval,
 		reporterIntervalHelp)
+	fs.Float64Var(&args.ReporterJitter, "reporter-jitter", defaultArgReporterJitter,
+		reporterJitterHelp)
 
 	fs.IntVar(&args.SamplesPerSecond, "samples-per-second", defaultArgSamplesPerSecond,
 		samplesPerSecondHelp)

--- a/collector/config/config.go
+++ b/collector/config/config.go
@@ -20,6 +20,7 @@ const (
 // Config is the configuration for the collector.
 type Config struct {
 	ReporterInterval       time.Duration `mapstructure:"reporter_interval"`
+	ReporterJitter         float64       `mapstructure:"reporter_jitter"`
 	MonitorInterval        time.Duration `mapstructure:"monitor_interval"`
 	SamplesPerSecond       int           `mapstructure:"samples_per_second"`
 	ProbabilisticInterval  time.Duration `mapstructure:"probabilistic_interval"`
@@ -78,6 +79,12 @@ func (cfg *Config) Validate() error {
 		return errors.New(
 			"invalid argument for off-cpu-threshold. The value " +
 				"should be in the range [0..1]. 0 disables off-cpu profiling")
+	}
+
+	if cfg.ReporterJitter < 0.0 || cfg.ReporterJitter > 1.0 {
+		return errors.New(
+			"invalid argument for reporter-jitter. The value " +
+				"should be in the range [0..1]. 0 disables jitter")
 	}
 
 	if !cfg.NoKernelVersionCheck {

--- a/collector/factory.go
+++ b/collector/factory.go
@@ -67,6 +67,7 @@ func BuildProfilesReceiver(options ...Option) xreceiver.CreateProfilesFunc {
 func defaultConfig() component.Config {
 	return &config.Config{
 		ReporterInterval:       5 * time.Second,
+		ReporterJitter:         0.2,
 		MonitorInterval:        5 * time.Second,
 		SamplesPerSecond:       20,
 		ProbabilisticInterval:  1 * time.Minute,

--- a/collector/internal/controller.go
+++ b/collector/internal/controller.go
@@ -49,6 +49,7 @@ func NewController(cfg *controller.Config, rs receiver.Settings,
 		GRPCStartupBackoffTime: intervals.GRPCStartupBackoffTime(),
 		GRPCConnectionTimeout:  intervals.GRPCConnectionTimeout(),
 		ReportInterval:         intervals.ReportInterval(),
+		ReportJitter:           cfg.ReporterJitter,
 		SamplesPerSecond:       cfg.SamplesPerSecond,
 	}, nextConsumer)
 	if err != nil {

--- a/interpreter/hotspot/data.go
+++ b/interpreter/hotspot/data.go
@@ -379,7 +379,7 @@ func (d *hotspotData) Attach(_ interpreter.EbpfHandler, _ libpf.PID, bias libpf.
 		addrToJITInfo:  addrToJITInfo,
 		addrToStubName: addrToStubName,
 		prefixes:       libpf.Set[lpm.Prefix]{},
-		stubs:          map[libpf.Address]StubRoutine{},
+		stubs:          xsync.NewRWMutex(map[libpf.Address]StubRoutine{}),
 	}, nil
 }
 

--- a/interpreter/hotspot/data.go
+++ b/interpreter/hotspot/data.go
@@ -602,7 +602,7 @@ func (d *hotspotData) newVMData(rm remotememory.RemoteMemory, bias libpf.Address
 		vms.CodeBlob.RelocationSize = 0
 	}
 
-	// JDK26+: immutable data size is defined by ref count trailer, not present prior to JDK26
+	// JDK26+: immutable data has a ref count trailer; not present prior to JDK26
 	if vms.Nmethod.ImmutableDataRefCountOff == ^uint(0) {
 		vms.Nmethod.ImmutableDataRefCountOff = 0
 	}

--- a/interpreter/hotspot/data.go
+++ b/interpreter/hotspot/data.go
@@ -173,7 +173,7 @@ type hotspotVMData struct {
 			DependenciesOffset       uint `name:"_dependencies_offset"`             // JDK -22 only
 			ImmutableData            uint `name:"_immutable_data"`                  // JDK 23+ only
 			ImmutableDataSize        uint `name:"_immutable_data_size"`             // JDK 23+ only
-			ImmutableDataRefCountOff uint `name:"_immutable_data_ref_count_offset"` // JDK 26 only
+			ImmutableDataRefCountOff uint `name:"_immutable_data_ref_count_offset"` // JDK 26+ only
 			OrigPcOffset             uint `name:"_orig_pc_offset"`
 			DeoptimizeOffset         uint `name:"_deoptimize_offset,_deopt_handler_offset,_deopt_handler_begin,_deopt_handler_entry_offset"`
 			Method                   uint `name:"_method"`

--- a/interpreter/hotspot/data.go
+++ b/interpreter/hotspot/data.go
@@ -603,7 +603,7 @@ func (d *hotspotData) newVMData(rm remotememory.RemoteMemory, bias libpf.Address
 	}
 
 	// JDK26+: immutable data size is defined by ref count trailer, not present prior JDK26
-	if vms.Nmethod.ImmutableDataRefCountOff != ^uint(0) {
+	if vms.Nmethod.ImmutableDataRefCountOff == ^uint(0) {
 		vms.Nmethod.ImmutableDataRefCountOff = 0
 	}
 

--- a/interpreter/hotspot/data.go
+++ b/interpreter/hotspot/data.go
@@ -602,6 +602,11 @@ func (d *hotspotData) newVMData(rm remotememory.RemoteMemory, bias libpf.Address
 		vms.CodeBlob.RelocationSize = 0
 	}
 
+	// JDK26+: immutable data size is defined by ref count trailer, not present prior JDK26
+	if vms.Nmethod.ImmutableDataRefCountOff != ^uint(0) {
+		vms.Nmethod.ImmutableDataRefCountOff = 0
+	}
+
 	// Check that all symbols got loaded from JVM introspection data
 	err := forEachItem("", reflect.ValueOf(&vmd.vmStructs).Elem(),
 		func(item reflect.Value, name string) error {

--- a/interpreter/hotspot/data.go
+++ b/interpreter/hotspot/data.go
@@ -602,7 +602,7 @@ func (d *hotspotData) newVMData(rm remotememory.RemoteMemory, bias libpf.Address
 		vms.CodeBlob.RelocationSize = 0
 	}
 
-	// JDK26+: immutable data size is defined by ref count trailer, not present prior JDK26
+	// JDK26+: immutable data size is defined by ref count trailer, not present prior to JDK26
 	if vms.Nmethod.ImmutableDataRefCountOff == ^uint(0) {
 		vms.Nmethod.ImmutableDataRefCountOff = 0
 	}

--- a/interpreter/hotspot/data.go
+++ b/interpreter/hotspot/data.go
@@ -166,17 +166,18 @@ type hotspotVMData struct {
 			ConstMethod uint `name:"_constMethod"`
 		} `name:"Method,methodOopDesc"`
 		Nmethod struct { // .Sizeof >256
-			Sizeof             uint
-			CompileID          uint `name:"_compile_id"`
-			MetadataOffset     uint `name:"_metadata_offset,_oops_offset"`
-			ScopesPcsOffset    uint `name:"_scopes_pcs_offset"`
-			DependenciesOffset uint `name:"_dependencies_offset"` // JDK -22 only
-			ImmutableData      uint `name:"_immutable_data"`      // JDK 23+ only
-			ImmutableDataSize  uint `name:"_immutable_data_size"` // JDK 23+ only
-			OrigPcOffset       uint `name:"_orig_pc_offset"`
-			DeoptimizeOffset   uint `name:"_deoptimize_offset,_deopt_handler_offset,_deopt_handler_begin"`
-			Method             uint `name:"_method"`
-			ScopesDataOffset   uint `name:"_scopes_data_offset,_scopes_data_begin"`
+			Sizeof                   uint
+			CompileID                uint `name:"_compile_id"`
+			MetadataOffset           uint `name:"_metadata_offset,_oops_offset"`
+			ScopesPcsOffset          uint `name:"_scopes_pcs_offset"`
+			DependenciesOffset       uint `name:"_dependencies_offset"`             // JDK -22 only
+			ImmutableData            uint `name:"_immutable_data"`                  // JDK 23+ only
+			ImmutableDataSize        uint `name:"_immutable_data_size"`             // JDK 23+ only
+			ImmutableDataRefCountOff uint `name:"_immutable_data_ref_count_offset"` // JDK 26 only
+			OrigPcOffset             uint `name:"_orig_pc_offset"`
+			DeoptimizeOffset         uint `name:"_deoptimize_offset,_deopt_handler_offset,_deopt_handler_begin,_deopt_handler_entry_offset"`
+			Method                   uint `name:"_method"`
+			ScopesDataOffset         uint `name:"_scopes_data_offset,_scopes_data_begin"`
 		} `name:"nmethod,CompiledMethod"`
 		OopDesc struct {
 			Sizeof uint

--- a/interpreter/hotspot/hotspot.go
+++ b/interpreter/hotspot/hotspot.go
@@ -78,6 +78,13 @@ package hotspot // import "go.opentelemetry.io/ebpf-profiler/interpreter/hotspot
 //  JDK24 - Tested ok
 //   - nmethod metadata moved to codeblob mutable data area
 //  JDK25 - Tested ok
+//  JDK26 - Tested ok
+//   - nmethod._deopt_handler_offset renamed to _deopt_handler_entry_offset
+//   - _deopt_mh_handler_offset removed
+//   - _has_method_handle_invokes removed from nmethod
+//   - PcDesc flags renumbered (method_handle_invoke flag removed)
+//   - immutable_data now has ref count trailer (_immutable_data_ref_count_offset)
+//   - nmethod relocation support added (transparent for profiler)
 //
 // NOTE: Ahead-Of-Time compilation (AOT) is NOT SUPPORTED. The main complication is that, the AOT
 // ELF files are mapped directly to the program virtual space, and contain the code to execute.

--- a/interpreter/hotspot/hotspot.go
+++ b/interpreter/hotspot/hotspot.go
@@ -80,11 +80,7 @@ package hotspot // import "go.opentelemetry.io/ebpf-profiler/interpreter/hotspot
 //  JDK25 - Tested ok
 //  JDK26 - Tested ok
 //   - nmethod._deopt_handler_offset renamed to _deopt_handler_entry_offset
-//   - _deopt_mh_handler_offset removed
-//   - _has_method_handle_invokes removed from nmethod
-//   - PcDesc flags renumbered (method_handle_invoke flag removed)
 //   - immutable_data now has ref count trailer (_immutable_data_ref_count_offset)
-//   - nmethod relocation support added (transparent for profiler)
 //
 // NOTE: Ahead-Of-Time compilation (AOT) is NOT SUPPORTED. The main complication is that, the AOT
 // ELF files are mapped directly to the program virtual space, and contain the code to execute.

--- a/interpreter/hotspot/instance.go
+++ b/interpreter/hotspot/instance.go
@@ -21,6 +21,7 @@ import (
 	"go.opentelemetry.io/ebpf-profiler/interpreter"
 	"go.opentelemetry.io/ebpf-profiler/libpf"
 	"go.opentelemetry.io/ebpf-profiler/libpf/pfunsafe"
+	"go.opentelemetry.io/ebpf-profiler/libpf/xsync"
 	"go.opentelemetry.io/ebpf-profiler/lpm"
 	"go.opentelemetry.io/ebpf-profiler/metrics"
 	npsr "go.opentelemetry.io/ebpf-profiler/nopanicslicereader"
@@ -91,7 +92,7 @@ type hotspotInstance struct {
 	heapAreas []jitArea
 
 	// stubs stores all known stub routine regions.
-	stubs map[libpf.Address]StubRoutine
+	stubs xsync.RWMutex[map[libpf.Address]StubRoutine]
 }
 
 func (d *hotspotInstance) GetAndResetMetrics() ([]metrics.Metric, error) {
@@ -242,12 +243,14 @@ func (d *hotspotInstance) getStubName(ripOrBci uint32, addr libpf.Address) libpf
 	stubName := d.rm.String(constStubNameAddr)
 
 	a := d.rm.Ptr(addr+libpf.Address(vms.CodeBlob.CodeBegin)) + libpf.Address(ripOrBci)
-	for _, stub := range d.stubs {
+	stubs := d.stubs.RLock()
+	for _, stub := range *stubs {
 		if stub.start <= a && stub.end > a {
 			stubName = fmt.Sprintf("%s [%s]", stubName, stub.name)
 			break
 		}
 	}
+	d.stubs.RUnlock(&stubs)
 	name := libpf.Intern(stubName)
 	d.addrToStubName.Add(addr, name)
 	return name
@@ -793,12 +796,17 @@ func (d *hotspotInstance) populateMainMappings(vmd *hotspotVMData,
 func (d *hotspotInstance) updateStubMappings(vmd *hotspotVMData,
 	ebpf interpreter.EbpfHandler, pid libpf.PID,
 ) {
-	for _, stub := range findStubBounds(vmd, d.bias, d.rm) {
-		if _, exists := d.stubs[stub.start]; exists {
+	allStubs := findStubBounds(vmd, d.bias, d.rm)
+
+	stubs := d.stubs.WLock()
+	defer d.stubs.WUnlock(&stubs)
+
+	for _, stub := range allStubs {
+		if _, exists := (*stubs)[stub.start]; exists {
 			continue
 		}
 
-		d.stubs[stub.start] = stub
+		(*stubs)[stub.start] = stub
 
 		// Separate stub areas are only required on ARM64.
 		if runtime.GOARCH != "arm64" {

--- a/interpreter/hotspot/instance.go
+++ b/interpreter/hotspot/instance.go
@@ -535,6 +535,15 @@ func (d *hotspotInstance) getJITInfo(addr libpf.Address, addrCheck uint32) (
 		scopesDataOff := npsr.PtrDiff32(nmethod, vms.Nmethod.ScopesDataOffset)
 		immutableDataPtr := npsr.Ptr(nmethod, vms.Nmethod.ImmutableData)
 		immutableDataSize := npsr.Uint32(nmethod, vms.Nmethod.ImmutableDataSize)
+
+		// JDK26+: immutable data ends at ref_count offset, not at immutable_data_size
+		if vms.Nmethod.ImmutableDataRefCountOff != 0 {
+			immutableDataRefCountOff := npsr.Uint32(nmethod, vms.Nmethod.ImmutableDataRefCountOff)
+			if immutableDataRefCountOff < immutableDataSize {
+				immutableDataSize = immutableDataRefCountOff
+			}
+		}
+
 		if immutableDataSize >= maxMetadataSize {
 			return nil, fmt.Errorf("unreasonably large immutable data region: %d bytes",
 				immutableDataSize)

--- a/interpreter/hotspot/instance.go
+++ b/interpreter/hotspot/instance.go
@@ -511,9 +511,9 @@ func (d *hotspotInstance) getJITInfo(addr libpf.Address, addrCheck uint32) (
 		// [scopes_data]	@ _immutable_data + nmethod._scopes_data_begin	\ arrays we need
 		// [scopes_pcs]		@ _immutable_data + nmethod._scopes_pcs_offset	/ for inlining info
 		// [speculations]	@ _immutable_data + nmethod._speculations_offset
-		// [end]		    @ _immutable_Data + nmethod._immutable_data_size
+		// [end]		    @ _immutable_data + nmethod._immutable_data_size
 		// [end]            @ _immutable_data + min(_immutable_data_size, _immutable_data_ref_count_offset)  (JDK 26+)
-		// // ...
+		// ...
 		// speculations presence depends on JDK build, and is not used. Instead the scopes
 		// end is determined from immutable data size.
 

--- a/interpreter/hotspot/instance.go
+++ b/interpreter/hotspot/instance.go
@@ -511,8 +511,9 @@ func (d *hotspotInstance) getJITInfo(addr libpf.Address, addrCheck uint32) (
 		// [scopes_data]	@ _immutable_data + nmethod._scopes_data_begin	\ arrays we need
 		// [scopes_pcs]		@ _immutable_data + nmethod._scopes_pcs_offset	/ for inlining info
 		// [speculations]	@ _immutable_data + nmethod._speculations_offset
-		// [end]		@ _immutable_Data + nmethod._immutable_data_size
-		// ...
+		// [end]		    @ _immutable_Data + nmethod._immutable_data_size
+		// [end]            @ _immutable_data + min(_immutable_data_size, _immutable_data_ref_count_offset)  (JDK 26+)
+		// // ...
 		// speculations presence depends on JDK build, and is not used. Instead the scopes
 		// end is determined from immutable data size.
 

--- a/interpreter/hotspot/instance_test.go
+++ b/interpreter/hotspot/instance_test.go
@@ -6,14 +6,14 @@ package hotspot
 import (
 	"bytes"
 	"encoding/binary"
+	"fmt"
 	"strings"
+	"sync"
 	"testing"
 
-	"github.com/elastic/go-freelru"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/ebpf-profiler/libpf"
-	"go.opentelemetry.io/ebpf-profiler/lpm"
 	"go.opentelemetry.io/ebpf-profiler/remotememory"
 )
 
@@ -31,16 +31,9 @@ func TestJavaSymbolExtraction(t *testing.T) {
 	rd := bytes.NewReader(sym)
 	rm := remotememory.RemoteMemory{ReaderAt: rd}
 
-	addrToSymbol, err := freelru.New[libpf.Address, libpf.String](2, libpf.Address.Hash32)
+	instance, err := id.Attach(nil, 0, 0, rm)
 	require.NoError(t, err, "symbol cache failed")
-
-	ii := hotspotInstance{
-		d:            &id,
-		rm:           rm,
-		addrToSymbol: addrToSymbol,
-		prefixes:     libpf.Set[lpm.Prefix]{},
-		stubs:        map[libpf.Address]StubRoutine{},
-	}
+	ii := instance.(*hotspotInstance)
 
 	str := strings.Repeat("a", maxLength)
 	copy(sym[vmd.vmStructs.Symbol.Body:], str)
@@ -50,4 +43,78 @@ func TestJavaSymbolExtraction(t *testing.T) {
 		assert.Equal(t, str[:i], got.String(), "symbol length %d mismatched read", i)
 		ii.addrToSymbol.Purge()
 	}
+}
+
+// TestStubsMapRace verifies there is no data race on concurrent
+// read and write access to d.stubs.
+func TestStubsMapRace(t *testing.T) {
+	const (
+		fieldName      = 0
+		fieldCodeBegin = 8
+	)
+
+	const (
+		codeBeginAddr = 0x1000
+		numStubs      = 50
+		stubSpacing   = 128
+		// based on value defined in findStubBounds() in stubs.go
+		maxStubLen = 8 * 1024
+		blobName   = "StubCode"
+	)
+
+	const (
+		slotsBase  = 16
+		slotsEnd   = slotsBase + numStubs*8
+		nameBase   = slotsEnd
+		codeBase   = 1024
+		bufSize    = codeBase + numStubs*stubSpacing + maxStubLen
+		iterations = 500
+	)
+
+	buf := make([]byte, bufSize)
+	binary.LittleEndian.PutUint64(buf[fieldName:], nameBase)
+	binary.LittleEndian.PutUint64(buf[fieldCodeBegin:], codeBeginAddr)
+	copy(buf[nameBase:], blobName)
+
+	catchAll := make(map[string]libpf.Address, numStubs)
+	for i := range numStubs {
+		slot := libpf.Address(slotsBase + i*8)
+		stubAddr := uint64(codeBase + i*stubSpacing)
+		binary.LittleEndian.PutUint64(buf[slot:], stubAddr)
+		catchAll[fmt.Sprintf("_stub_%d", i)] = slot
+	}
+
+	rd := bytes.NewReader(buf)
+	rm := remotememory.RemoteMemory{ReaderAt: rd}
+
+	id := hotspotData{}
+	vmd, _ := id.GetOrInit(func() (hotspotVMData, error) {
+		vmd := hotspotVMData{}
+		vmd.vmStructs.CodeBlob.Name = fieldName
+		vmd.vmStructs.CodeBlob.CodeBegin = fieldCodeBegin
+		vmd.vmStructs.StubRoutines.CatchAll = catchAll
+		return vmd, nil
+	})
+
+	instance, err := id.Attach(nil, 0, 0, rm)
+	require.NoError(t, err)
+	ii := instance.(*hotspotInstance)
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for range iterations {
+			ii.updateStubMappings(vmd, nil, 0)
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for range iterations {
+			ii.addrToStubName.Purge()
+			ii.getStubName(0, 0)
+		}
+	}()
+
+	wg.Wait()
 }

--- a/main.go
+++ b/main.go
@@ -117,6 +117,7 @@ func mainWithExitCode() exitCode {
 		GRPCStartupBackoffTime: intervals.GRPCStartupBackoffTime(),
 		GRPCConnectionTimeout:  intervals.GRPCConnectionTimeout(),
 		ReportInterval:         intervals.ReportInterval(),
+		ReportJitter:           cfg.ReporterJitter,
 		SamplesPerSecond:       cfg.SamplesPerSecond,
 	})
 	if err != nil {

--- a/reporter/base_reporter.go
+++ b/reporter/base_reporter.go
@@ -6,6 +6,7 @@ package reporter // import "go.opentelemetry.io/ebpf-profiler/reporter"
 import (
 	"errors"
 	"fmt"
+	"time"
 
 	"go.opentelemetry.io/ebpf-profiler/libpf"
 	"go.opentelemetry.io/ebpf-profiler/libpf/xsync"
@@ -32,6 +33,11 @@ type baseReporter struct {
 
 	// traceEvents stores reported trace events (trace metadata with frames and counts)
 	traceEvents xsync.RWMutex[samples.TraceEventsTree]
+
+	// collectionStartTime tracks when the current collection window started.
+	// Initialized when Start() is called. The duration of the first profile may be
+	// slightly overestimated as it includes tracer setup time before samples arrive.
+	collectionStartTime time.Time
 }
 
 var errUnknownOrigin = errors.New("unknown trace origin")

--- a/reporter/collector_reporter.go
+++ b/reporter/collector_reporter.go
@@ -5,6 +5,7 @@ package reporter // import "go.opentelemetry.io/ebpf-profiler/reporter"
 
 import (
 	"context"
+	"time"
 
 	"go.opentelemetry.io/collector/consumer/xconsumer"
 	"go.opentelemetry.io/ebpf-profiler/internal/log"
@@ -53,6 +54,8 @@ func NewCollector(cfg *Config, nextConsumer xconsumer.Profiles) (*CollectorRepor
 }
 
 func (r *CollectorReporter) Start(ctx context.Context) error {
+	r.collectionStartTime = time.Now()
+
 	// Create a child context for reporting features
 	ctx, cancelReporting := context.WithCancel(ctx)
 
@@ -82,9 +85,13 @@ func (r *CollectorReporter) reportProfile(ctx context.Context) error {
 	reportedEvents := (*traceEventsPtr)
 	newEvents := make(samples.TraceEventsTree)
 	*traceEventsPtr = newEvents
+	collectionEndTime := time.Now()
+	collectionStartTime := r.collectionStartTime
+	r.collectionStartTime = collectionEndTime
 	r.traceEvents.WUnlock(&traceEventsPtr)
 
-	profiles, err := r.pdata.Generate(reportedEvents, r.name, r.version)
+	profiles, err := r.pdata.Generate(reportedEvents, r.name, r.version,
+		collectionStartTime, collectionEndTime)
 	if err != nil {
 		log.Errorf("pdata: %v", err)
 		return nil

--- a/reporter/collector_reporter.go
+++ b/reporter/collector_reporter.go
@@ -56,7 +56,7 @@ func (r *CollectorReporter) Start(ctx context.Context) error {
 	// Create a child context for reporting features
 	ctx, cancelReporting := context.WithCancel(ctx)
 
-	r.runLoop.Start(ctx, r.cfg.ReportInterval, func() {
+	r.runLoop.Start(ctx, r.cfg.ReportInterval, r.cfg.ReportJitter, func() {
 		if err := r.reportProfile(context.Background()); err != nil {
 			log.Errorf("Request failed: %v", err)
 		}

--- a/reporter/config.go
+++ b/reporter/config.go
@@ -36,6 +36,7 @@ type Config struct {
 	GRPCStartupBackoffTime time.Duration
 	GRPCConnectionTimeout  time.Duration
 	ReportInterval         time.Duration
+	ReportJitter           float64
 
 	// gRPCInterceptor is the client gRPC interceptor, e.g., for sending gRPC metadata.
 	GRPCClientInterceptor grpc.UnaryClientInterceptor

--- a/reporter/internal/pdata/generate.go
+++ b/reporter/internal/pdata/generate.go
@@ -5,7 +5,6 @@ package pdata // import "go.opentelemetry.io/ebpf-profiler/reporter/internal/pda
 
 import (
 	"fmt"
-	"math"
 	"path/filepath"
 	"time"
 
@@ -27,12 +26,34 @@ const (
 )
 
 // Generate generates a pdata request out of internal profiles data, to be
-// exported.
+// exported. The collectionStartTime and collectionEndTime define the time window
+// during which the profiler was actively collecting samples.
 func (p *Pdata) Generate(tree samples.TraceEventsTree,
 	agentName, agentVersion string,
+	collectionStartTime, collectionEndTime time.Time,
 ) (pprofile.Profiles, error) {
 	profiles := pprofile.NewProfiles()
 	dic := profiles.Dictionary()
+
+	// Find oldest sample timestamp across all containers to handle buffered samples.
+	adjustedStartTime := collectionStartTime
+	for _, containerEvents := range tree {
+		for _, originEvents := range containerEvents {
+			for _, traceEvents := range originEvents {
+				for _, ts := range traceEvents.Timestamps {
+					sampleTime := time.Unix(0, int64(ts))
+					if sampleTime.Before(adjustedStartTime) {
+						adjustedStartTime = sampleTime
+					}
+				}
+			}
+		}
+	}
+	if adjustedStartTime.Before(collectionStartTime) {
+		log.Debugf("Adjusted profile start time backward by %v to include oldest sample",
+			collectionStartTime.Sub(adjustedStartTime))
+	}
+	collectionStartTime = adjustedStartTime
 
 	// Temporary helpers that will build the various tables in ProfilesDictionary.
 	stringSet := make(orderedset.OrderedSet[string], 64)
@@ -84,7 +105,8 @@ func (p *Pdata) Generate(tree samples.TraceEventsTree,
 			prof := sp.Profiles().AppendEmpty()
 			if err := p.setProfile(dic,
 				attrMgr, stringSet, funcSet, mappingSet, stackSet, locationSet,
-				origin, originToEvents[origin], prof); err != nil {
+				origin, originToEvents[origin], prof,
+				collectionStartTime, collectionEndTime); err != nil {
 				return profiles, err
 			}
 		}
@@ -124,6 +146,7 @@ func (p *Pdata) setProfile(
 	origin libpf.Origin,
 	events map[samples.TraceAndMetaKey]*samples.TraceEvents,
 	profile pprofile.Profile,
+	collectionStartTime, collectionEndTime time.Time,
 ) error {
 	st := profile.SampleType()
 	switch origin {
@@ -146,14 +169,8 @@ func (p *Pdata) setProfile(
 		return fmt.Errorf("generating profile for unsupported origin %d", origin)
 	}
 
-	startTS, endTS := uint64(math.MaxUint64), uint64(0)
 	for traceKey, traceInfo := range events {
 		sample := profile.Samples().AppendEmpty()
-
-		for _, ts := range traceInfo.Timestamps {
-			startTS = min(startTS, ts)
-			endTS = max(endTS, ts)
-		}
 
 		sample.TimestampsUnixNano().FromRaw(traceInfo.Timestamps)
 		if origin == support.TraceOriginOffCPU {
@@ -280,8 +297,8 @@ func (p *Pdata) setProfile(
 
 	log.Debugf("Reporting OTLP profile with %d samples", profile.Samples().Len())
 
-	profile.SetDurationNano(endTS - startTS)
-	profile.SetTime(pcommon.Timestamp(startTS))
+	profile.SetDurationNano(uint64(collectionEndTime.Sub(collectionStartTime).Nanoseconds()))
+	profile.SetTime(pcommon.Timestamp(collectionStartTime.UnixNano()))
 
 	return nil
 }

--- a/reporter/otlp_reporter.go
+++ b/reporter/otlp_reporter.go
@@ -71,6 +71,8 @@ func NewOTLP(cfg *Config) (*OTLPReporter, error) {
 
 // Start sets up and manages the reporting connection to a OTLP backend.
 func (r *OTLPReporter) Start(ctx context.Context) error {
+	r.collectionStartTime = time.Now()
+
 	// Create a child context for reporting features
 	ctx, cancelReporting := context.WithCancel(ctx)
 
@@ -114,9 +116,13 @@ func (r *OTLPReporter) reportOTLPProfile(ctx context.Context) error {
 	reportedEvents := (*traceEventsPtr)
 	newEvents := make(samples.TraceEventsTree)
 	*traceEventsPtr = newEvents
+	collectionEndTime := time.Now()
+	collectionStartTime := r.collectionStartTime
+	r.collectionStartTime = collectionEndTime
 	r.traceEvents.WUnlock(&traceEventsPtr)
 
-	profiles, err := r.pdata.Generate(reportedEvents, r.name, r.version)
+	profiles, err := r.pdata.Generate(reportedEvents, r.name, r.version,
+		collectionStartTime, collectionEndTime)
 	if err != nil {
 		log.Errorf("pdata: %v", err)
 		return nil

--- a/reporter/otlp_reporter.go
+++ b/reporter/otlp_reporter.go
@@ -85,7 +85,7 @@ func (r *OTLPReporter) Start(ctx context.Context) error {
 	}
 	r.client = pprofileotlp.NewGRPCClient(otlpGrpcConn)
 
-	r.runLoop.Start(ctx, r.cfg.ReportInterval, func() {
+	r.runLoop.Start(ctx, r.cfg.ReportInterval, r.cfg.ReportJitter, func() {
 		if err := r.reportOTLPProfile(ctx); err != nil {
 			log.Errorf("Request failed: %v", err)
 		}

--- a/reporter/runloop.go
+++ b/reporter/runloop.go
@@ -16,7 +16,8 @@ type runLoop struct {
 	stopSignal chan libpf.Void
 }
 
-func (rl *runLoop) Start(ctx context.Context, reportInterval time.Duration, run, purge func()) {
+func (rl *runLoop) Start(ctx context.Context, reportInterval time.Duration, jitter float64,
+	run, purge func()) {
 	go func() {
 		tick := time.NewTicker(reportInterval)
 		defer tick.Stop()
@@ -31,7 +32,7 @@ func (rl *runLoop) Start(ctx context.Context, reportInterval time.Duration, run,
 				return
 			case <-tick.C:
 				run()
-				tick.Reset(libpf.AddJitter(reportInterval, 0.2))
+				tick.Reset(libpf.AddJitter(reportInterval, jitter))
 			case <-purgeTick.C:
 				purge()
 			}

--- a/tools/coredump/testdata/amd64/java26-deopt.json
+++ b/tools/coredump/testdata/amd64/java26-deopt.json
@@ -1,0 +1,398 @@
+{
+  "coredump-ref": "cea3ba7fcde2a7752d5acae408e8952a02e294c13b9ba2dff5a3ed940dd4ccff",
+  "threads": [
+    {
+      "lwp": 25424,
+      "frames": [
+        "libc.so.6+0x98d71",
+        "libc.so.6+0x9e7a2",
+        "libjli.so+0x8d5b",
+        "libjli.so+0x5ebc",
+        "libjli.so+0x6bfe",
+        "java+0xada",
+        "libc.so.6+0x2a1c9",
+        "libc.so.6+0x2a28a",
+        "java+0xb78",
+        "<unwinding aborted due to error native_stack_delta_invalid>"
+      ]
+    },
+    {
+      "lwp": 25446,
+      "frames": [
+        "libc.so.6+0x98d71",
+        "libc.so.6+0x9bc8d",
+        "libjvm.so+0xe438c6",
+        "libjvm.so+0xe0f823",
+        "libjvm.so+0x10106ea",
+        "libjvm.so+0xae8334",
+        "void java.lang.Object.wait0(long)+0 in Object.java:0",
+        "void java.lang.Object.wait(long)+13 in Object.java:391",
+        "java.lang.ref.Reference java.lang.ref.ReferenceQueue.remove0(long)+4 in ReferenceQueue.java:123",
+        "java.lang.ref.Reference java.lang.ref.ReferenceQueue.remove(long)+6 in ReferenceQueue.java:201",
+        "void jdk.internal.ref.CleanerImpl.run()+18 in CleanerImpl.java:146",
+        "void java.lang.Thread.runWith(java.lang.Object, java.lang.Runnable)+1 in Thread.java:1529",
+        "void java.lang.Thread.run()+3 in Thread.java:1516",
+        "void jdk.internal.misc.InnocuousThread.run()+2 in InnocuousThread.java:148",
+        "StubRoutines (initial stubs)+0 in :0",
+        "libjvm.so+0x9e8b5f",
+        "libjvm.so+0x9ea4ae",
+        "libjvm.so+0xadf78b",
+        "libjvm.so+0xa02867",
+        "libjvm.so+0x106219e",
+        "libjvm.so+0xe37825",
+        "libc.so.6+0x9caa3",
+        "libc.so.6+0x129c6b"
+      ]
+    },
+    {
+      "lwp": 25445,
+      "frames": [
+        "libc.so.6+0x98d71",
+        "libc.so.6+0x9b7ec",
+        "libjvm.so+0xe43f4b",
+        "libjvm.so+0xde53f8",
+        "libjvm.so+0xe03599",
+        "libjvm.so+0xa02867",
+        "libjvm.so+0x106219e",
+        "libjvm.so+0xe37825",
+        "libc.so.6+0x9caa3",
+        "libc.so.6+0x129c6b"
+      ]
+    },
+    {
+      "lwp": 25444,
+      "frames": [
+        "libc.so.6+0x98d71",
+        "libc.so.6+0x9bc8d",
+        "libjvm.so+0xe43ebb",
+        "libjvm.so+0xde547d",
+        "libjvm.so+0x7098da",
+        "libjvm.so+0x70cb46",
+        "libjvm.so+0xa02867",
+        "libjvm.so+0x106219e",
+        "libjvm.so+0xe37825",
+        "libc.so.6+0x9caa3",
+        "libc.so.6+0x129c6b"
+      ]
+    },
+    {
+      "lwp": 25443,
+      "frames": [
+        "libc.so.6+0x98d71",
+        "libc.so.6+0x9bc8d",
+        "libjvm.so+0xe43ebb",
+        "libjvm.so+0xde547d",
+        "libjvm.so+0x7098da",
+        "libjvm.so+0x70cb46",
+        "libjvm.so+0xa02867",
+        "libjvm.so+0x106219e",
+        "libjvm.so+0xe37825",
+        "libc.so.6+0x9caa3",
+        "libc.so.6+0x129c6b"
+      ]
+    },
+    {
+      "lwp": 25442,
+      "frames": [
+        "libc.so.6+0x98d71",
+        "libc.so.6+0x9bc8d",
+        "libjvm.so+0xe43ebb",
+        "libjvm.so+0xde53f8",
+        "libjvm.so+0xdd6f8a",
+        "libjvm.so+0xa02867",
+        "libjvm.so+0x106219e",
+        "libjvm.so+0xe37825",
+        "libc.so.6+0x9caa3",
+        "libc.so.6+0x129c6b"
+      ]
+    },
+    {
+      "lwp": 25441,
+      "frames": [
+        "libc.so.6+0x98d71",
+        "libc.so.6+0x9bc8d",
+        "libjvm.so+0xe43ebb",
+        "libjvm.so+0xde53f8",
+        "libjvm.so+0xf0ae63",
+        "libjvm.so+0xa02867",
+        "libjvm.so+0x106219e",
+        "libjvm.so+0xe37825",
+        "libc.so.6+0x9caa3",
+        "libc.so.6+0x129c6b"
+      ]
+    },
+    {
+      "lwp": 25440,
+      "frames": [
+        "libc.so.6+0x98d71",
+        "libc.so.6+0xa4fb7",
+        "libjvm.so+0xefd991",
+        "libjvm.so+0xf2b2db",
+        "libjvm.so+0xe28734",
+        "libjvm.so+0xa02867",
+        "libjvm.so+0x106219e",
+        "libjvm.so+0xe37825",
+        "libc.so.6+0x9caa3",
+        "libc.so.6+0x129c6b"
+      ]
+    },
+    {
+      "lwp": 25439,
+      "frames": [
+        "libc.so.6+0x98d71",
+        "libc.so.6+0x9b7ec",
+        "libjvm.so+0xe4370a",
+        "libjvm.so+0xe0f953",
+        "libjvm.so+0x10106ea",
+        "libjvm.so+0xae8334",
+        "void java.lang.Object.wait0(long)+0 in Object.java:0",
+        "void java.lang.Object.wait(long)+13 in Object.java:391",
+        "void java.lang.Object.wait()+0 in Object.java:353",
+        "java.lang.ref.Reference java.lang.ref.ReferenceQueue.remove0()+2 in ReferenceQueue.java:137",
+        "java.lang.ref.Reference java.lang.ref.ReferenceQueue.remove()+1 in ReferenceQueue.java:215",
+        "void java.lang.ref.Finalizer$FinalizerThread.run()+7 in Finalizer.java:165",
+        "StubRoutines (initial stubs)+0 in :0",
+        "libjvm.so+0x9e8b5f",
+        "libjvm.so+0x9ea4ae",
+        "libjvm.so+0xadf78b",
+        "libjvm.so+0xa02867",
+        "libjvm.so+0x106219e",
+        "libjvm.so+0xe37825",
+        "libc.so.6+0x9caa3",
+        "libc.so.6+0x129c6b"
+      ]
+    },
+    {
+      "lwp": 25438,
+      "frames": [
+        "libc.so.6+0x98d71",
+        "libc.so.6+0x9b7ec",
+        "libjvm.so+0xe43f4b",
+        "libjvm.so+0xde547d",
+        "libjvm.so+0xae5aa1",
+        "void java.lang.ref.Reference.waitForReferencePendingList()+0 in Reference.java:0",
+        "void java.lang.ref.Reference.processPendingReferences()+0 in Reference.java:240",
+        "void java.lang.ref.Reference$ReferenceHandler.run()+0 in Reference.java:202",
+        "StubRoutines (initial stubs)+0 in :0",
+        "libjvm.so+0x9e8b5f",
+        "libjvm.so+0x9ea4ae",
+        "libjvm.so+0xadf78b",
+        "libjvm.so+0xa02867",
+        "libjvm.so+0x106219e",
+        "libjvm.so+0xe37825",
+        "libc.so.6+0x9caa3",
+        "libc.so.6+0x129c6b"
+      ]
+    },
+    {
+      "lwp": 25437,
+      "frames": [
+        "libc.so.6+0x98d71",
+        "libc.so.6+0x9b7ec",
+        "libjvm.so+0xe43f4b",
+        "libjvm.so+0xde53f8",
+        "libjvm.so+0x110471c",
+        "libjvm.so+0x1105087",
+        "libjvm.so+0x106219e",
+        "libjvm.so+0xe37825",
+        "libc.so.6+0x9caa3",
+        "libc.so.6+0x129c6b"
+      ]
+    },
+    {
+      "lwp": 25436,
+      "frames": [
+        "libc.so.6+0x98d71",
+        "libc.so.6+0x9bc8d",
+        "libjvm.so+0xe43ebb",
+        "libjvm.so+0xde53f8",
+        "libjvm.so+0xe02fea",
+        "libjvm.so+0xe03100",
+        "libjvm.so+0x106219e",
+        "libjvm.so+0xe37825",
+        "libc.so.6+0x9caa3",
+        "libc.so.6+0x129c6b"
+      ]
+    },
+    {
+      "lwp": 25431,
+      "frames": [
+        "libc.so.6+0x98d71",
+        "libc.so.6+0x9bc8d",
+        "libjvm.so+0xe43ebb",
+        "libjvm.so+0xde53f8",
+        "libjvm.so+0x9161a5",
+        "libjvm.so+0x91659f",
+        "libjvm.so+0x72737a",
+        "libjvm.so+0x106219e",
+        "libjvm.so+0xe37825",
+        "libc.so.6+0x9caa3",
+        "libc.so.6+0x129c6b"
+      ]
+    },
+    {
+      "lwp": 25430,
+      "frames": [
+        "libc.so.6+0x98d71",
+        "libc.so.6+0xa4fb7",
+        "libjvm.so+0xefd991",
+        "libjvm.so+0x113abca",
+        "libjvm.so+0x106219e",
+        "libjvm.so+0xe37825",
+        "libc.so.6+0x9caa3",
+        "libc.so.6+0x129c6b"
+      ]
+    },
+    {
+      "lwp": 25429,
+      "frames": [
+        "libc.so.6+0x98d71",
+        "libc.so.6+0x9b7ec",
+        "libjvm.so+0xe43f4b",
+        "libjvm.so+0xde53f8",
+        "libjvm.so+0x8a9dba",
+        "libjvm.so+0x72737a",
+        "libjvm.so+0x106219e",
+        "libjvm.so+0xe37825",
+        "libc.so.6+0x9caa3",
+        "libc.so.6+0x129c6b"
+      ]
+    },
+    {
+      "lwp": 25428,
+      "frames": [
+        "libc.so.6+0x98d71",
+        "libc.so.6+0xa4fb7",
+        "libjvm.so+0xefd991",
+        "libjvm.so+0x113abca",
+        "libjvm.so+0x106219e",
+        "libjvm.so+0xe37825",
+        "libc.so.6+0x9caa3",
+        "libc.so.6+0x129c6b"
+      ]
+    },
+    {
+      "lwp": 25427,
+      "frames": [
+        "libc.so.6+0x98d71",
+        "libc.so.6+0x9b7ec",
+        "libjvm.so+0xe43f4b",
+        "libjvm.so+0xde53f8",
+        "libjvm.so+0x89f269",
+        "libjvm.so+0x72737a",
+        "libjvm.so+0x106219e",
+        "libjvm.so+0xe37825",
+        "libc.so.6+0x9caa3",
+        "libc.so.6+0x129c6b"
+      ]
+    },
+    {
+      "lwp": 25426,
+      "frames": [
+        "libc.so.6+0x98d71",
+        "libc.so.6+0xa4fb7",
+        "libjvm.so+0xefd991",
+        "libjvm.so+0x113abca",
+        "libjvm.so+0x106219e",
+        "libjvm.so+0xe37825",
+        "libc.so.6+0x9caa3",
+        "libc.so.6+0x129c6b"
+      ]
+    },
+    {
+      "lwp": 25425,
+      "frames": [
+        "libc.so.6+0x11c5dd",
+        "libjava.so+0x16887",
+        "libjava.so+0x162ad",
+        "libjava.so+0xf036",
+        "void java.io.FileOutputStream.writeBytes(byte[], int, int, boolean)+0 in FileOutputStream.java:0",
+        "void java.io.FileOutputStream.write(byte[], int, int)+5 in FileOutputStream.java:352",
+        "void java.lang.System$Out.write(byte[], int, int)+2 in System.java:1911",
+        "void java.io.BufferedOutputStream.flushBuffer()+1 in BufferedOutputStream.java:123",
+        "void java.io.BufferedOutputStream.flush()+0 in BufferedOutputStream.java:203",
+        "void java.io.PrintStream.write(byte[], int, int)+4 in PrintStream.java:538",
+        "void sun.nio.cs.StreamEncoder.writeBytes()+7 in StreamEncoder.java:220",
+        "void sun.nio.cs.StreamEncoder.implFlushBuffer()+1 in StreamEncoder.java:315",
+        "void sun.nio.cs.StreamEncoder.flushBuffer()+2 in StreamEncoder.java:101",
+        "void java.io.OutputStreamWriter.flushBuffer()+0 in OutputStreamWriter.java:179",
+        "void java.io.PrintStream.write(java.lang.String)+4 in PrintStream.java:655",
+        "void java.io.PrintStream.print(java.lang.String)+0 in PrintStream.java:818",
+        "void Deopt.Handle(int)+9 in Deopt.java:20",
+        "void Deopt.Handle(int)+4 in Deopt.java:15",
+        "void Deopt.Handle(int)+4 in Deopt.java:15",
+        "void Deopt.Handle(int)+4 in Deopt.java:15",
+        "void Deopt.Handle(int)+4 in Deopt.java:15",
+        "void Deopt.Handle(int)+4 in Deopt.java:15",
+        "void Deopt.Handle(int)+4 in Deopt.java:15",
+        "void Deopt.Handle(int)+4 in Deopt.java:15",
+        "void Deopt.Handle(int)+4 in Deopt.java:15",
+        "void Deopt.Handle(int)+4 in Deopt.java:15",
+        "void Deopt.main(java.lang.String[])+3 in Deopt.java:31",
+        "StubRoutines (initial stubs)+0 in :0",
+        "libjvm.so+0x9e8b5f",
+        "libjvm.so+0xab6cd2",
+        "libjvm.so+0xab993e",
+        "libjli.so+0x3b79",
+        "libjli.so+0x4bff",
+        "libjli.so+0x8188",
+        "libc.so.6+0x9caa3",
+        "libc.so.6+0x129c6b"
+      ]
+    }
+  ],
+  "modules": [
+    {
+      "ref": "4970ab7d350b1de61085e816e00f931f7aa6354a83d6abbde46826ee9a334eea",
+      "local-path": "/home/ubuntu/jdk-26/lib/server/libjvm.so"
+    },
+    {
+      "ref": "9d1cefae4c0e4995cc35ea3195f805454b2d59a27ad15397a1096e735d341faf",
+      "local-path": "/usr/lib/x86_64-linux-gnu/librt.so.1"
+    },
+    {
+      "ref": "92dcea07a5b11d939c22a96131d3fbb995e0a84a4d02db7d799bf357689cd794",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libpthread.so.0"
+    },
+    {
+      "ref": "9b64150b28505a33d6bc3ecf709c279f6de97a1c184dbda65d06ee4537f6d286",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libz.so.1.3"
+    },
+    {
+      "ref": "ca8bb944728bfb437f812d68de480e34fe333abe5ea99ccc46b37f0c899edba3",
+      "local-path": "/home/ubuntu/jdk-26/lib/libjava.so"
+    },
+    {
+      "ref": "1b87a1a50b496cfead2b0ad134c2ff536705c82608db240c7e8aa48d6c0e4217",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libm.so.6"
+    },
+    {
+      "ref": "d8db8739a1633c972cec6a4fe0566bdcec6fd088f98723492ab0361f66238f75",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libc.so.6"
+    },
+    {
+      "ref": "911511065ea1603312a6f671ee5484f9c5a0d5e83a32280440ad74507c564f1a",
+      "local-path": "/home/ubuntu/jdk-26/lib/libjimage.so"
+    },
+    {
+      "ref": "850b46fd4f4478060fc106f4d1dc4aa35c969eb5c9bd98aaf64dc6cb3d6a5e32",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libdl.so.2"
+    },
+    {
+      "ref": "a89bc1d2b4b95774da97f32c78720a5778c6a76cb7a5dcda90275cdd4d460f4d",
+      "local-path": "/home/ubuntu/jdk-26/lib/libjli.so"
+    },
+    {
+      "ref": "1cd555ac46b7887edeaf3c42aac5408c8135e52f6b37870da2cf82d5fe14e829",
+      "local-path": "/usr/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2"
+    },
+    {
+      "ref": "8e459e410fbf3825894802e3899367e1fcb0adb6aa6e919bf7c333b405645471",
+      "local-path": "/home/ubuntu/jdk-26/bin/java"
+    },
+    {
+      "ref": "814a1fdeb48b8dd0a9bf54f2a122a93658fb4866783d1d7d693da71fb51de9f7",
+      "local-path": "/home/ubuntu/jdk-26/lib/libsimdsort.so"
+    }
+  ]
+}

--- a/tools/coredump/testdata/amd64/java26-prof2.json
+++ b/tools/coredump/testdata/amd64/java26-prof2.json
@@ -1,0 +1,438 @@
+{
+  "coredump-ref": "e590caaad59c0e57c803d4a79e39296b4015a57aa2d24d0a79efaa101249cd22",
+  "threads": [
+    {
+      "lwp": 28287,
+      "frames": [
+        "libc.so.6+0x98d71",
+        "libc.so.6+0x9e7a2",
+        "libjli.so+0x8d5b",
+        "libjli.so+0x5ebc",
+        "libjli.so+0x6bfe",
+        "java+0xada",
+        "libc.so.6+0x2a1c9",
+        "libc.so.6+0x2a28a",
+        "java+0xb78",
+        "<unwinding aborted due to error native_stack_delta_invalid>"
+      ]
+    },
+    {
+      "lwp": 28324,
+      "frames": [
+        "libc.so.6+0x98d71",
+        "libc.so.6+0xa4fb7",
+        "libjvm.so+0xefd991",
+        "libjvm.so+0x113abca",
+        "libjvm.so+0x106219e",
+        "libjvm.so+0xe37825",
+        "libc.so.6+0x9caa3",
+        "libc.so.6+0x129c6b"
+      ]
+    },
+    {
+      "lwp": 28323,
+      "frames": [
+        "libc.so.6+0x98d71",
+        "libc.so.6+0xa4fb7",
+        "libjvm.so+0xefd991",
+        "libjvm.so+0x113abca",
+        "libjvm.so+0x106219e",
+        "libjvm.so+0xe37825",
+        "libc.so.6+0x9caa3",
+        "libc.so.6+0x129c6b"
+      ]
+    },
+    {
+      "lwp": 28322,
+      "frames": [
+        "libc.so.6+0x98d71",
+        "libc.so.6+0xa4fb7",
+        "libjvm.so+0xefd991",
+        "libjvm.so+0x113abca",
+        "libjvm.so+0x106219e",
+        "libjvm.so+0xe37825",
+        "libc.so.6+0x9caa3",
+        "libc.so.6+0x129c6b"
+      ]
+    },
+    {
+      "lwp": 28321,
+      "frames": [
+        "libc.so.6+0x98d71",
+        "libc.so.6+0xa4fb7",
+        "libjvm.so+0xefd991",
+        "libjvm.so+0x113abca",
+        "libjvm.so+0x106219e",
+        "libjvm.so+0xe37825",
+        "libc.so.6+0x9caa3",
+        "libc.so.6+0x129c6b"
+      ]
+    },
+    {
+      "lwp": 28312,
+      "frames": [
+        "libc.so.6+0x98d71",
+        "libc.so.6+0xa4fb7",
+        "libjvm.so+0xefd991",
+        "libjvm.so+0x113abca",
+        "libjvm.so+0x106219e",
+        "libjvm.so+0xe37825",
+        "libc.so.6+0x9caa3",
+        "libc.so.6+0x129c6b"
+      ]
+    },
+    {
+      "lwp": 28309,
+      "frames": [
+        "libc.so.6+0x98d71",
+        "libc.so.6+0x9bc8d",
+        "libjvm.so+0xe438c6",
+        "libjvm.so+0xe0f823",
+        "libjvm.so+0x10106ea",
+        "libjvm.so+0xae8334",
+        "void java.lang.Object.wait0(long)+0 in Object.java:0",
+        "void java.lang.Object.wait(long)+13 in Object.java:391",
+        "java.lang.ref.Reference java.lang.ref.ReferenceQueue.remove0(long)+4 in ReferenceQueue.java:123",
+        "java.lang.ref.Reference java.lang.ref.ReferenceQueue.remove(long)+6 in ReferenceQueue.java:201",
+        "void jdk.internal.ref.CleanerImpl.run()+18 in CleanerImpl.java:146",
+        "void java.lang.Thread.runWith(java.lang.Object, java.lang.Runnable)+1 in Thread.java:1529",
+        "void java.lang.Thread.run()+3 in Thread.java:1516",
+        "void jdk.internal.misc.InnocuousThread.run()+2 in InnocuousThread.java:148",
+        "StubRoutines (initial stubs)+0 in :0",
+        "libjvm.so+0x9e8b5f",
+        "libjvm.so+0x9ea4ae",
+        "libjvm.so+0xadf78b",
+        "libjvm.so+0xa02867",
+        "libjvm.so+0x106219e",
+        "libjvm.so+0xe37825",
+        "libc.so.6+0x9caa3",
+        "libc.so.6+0x129c6b"
+      ]
+    },
+    {
+      "lwp": 28308,
+      "frames": [
+        "libc.so.6+0x98d71",
+        "libc.so.6+0x9b7ec",
+        "libjvm.so+0xe43f4b",
+        "libjvm.so+0xde53f8",
+        "libjvm.so+0xe03599",
+        "libjvm.so+0xa02867",
+        "libjvm.so+0x106219e",
+        "libjvm.so+0xe37825",
+        "libc.so.6+0x9caa3",
+        "libc.so.6+0x129c6b"
+      ]
+    },
+    {
+      "lwp": 28307,
+      "frames": [
+        "libc.so.6+0x98d71",
+        "libc.so.6+0x9bc8d",
+        "libjvm.so+0xe43ebb",
+        "libjvm.so+0xde547d",
+        "libjvm.so+0x7098da",
+        "libjvm.so+0x70cb46",
+        "libjvm.so+0xa02867",
+        "libjvm.so+0x106219e",
+        "libjvm.so+0xe37825",
+        "libc.so.6+0x9caa3",
+        "libc.so.6+0x129c6b"
+      ]
+    },
+    {
+      "lwp": 28306,
+      "frames": [
+        "libc.so.6+0x98d71",
+        "libc.so.6+0x9bc8d",
+        "libjvm.so+0xe43ebb",
+        "libjvm.so+0xde547d",
+        "libjvm.so+0x7098da",
+        "libjvm.so+0x70cb46",
+        "libjvm.so+0xa02867",
+        "libjvm.so+0x106219e",
+        "libjvm.so+0xe37825",
+        "libc.so.6+0x9caa3",
+        "libc.so.6+0x129c6b"
+      ]
+    },
+    {
+      "lwp": 28305,
+      "frames": [
+        "libc.so.6+0x98d71",
+        "libc.so.6+0x9bc8d",
+        "libjvm.so+0xe43ebb",
+        "libjvm.so+0xde53f8",
+        "libjvm.so+0xdd6f8a",
+        "libjvm.so+0xa02867",
+        "libjvm.so+0x106219e",
+        "libjvm.so+0xe37825",
+        "libc.so.6+0x9caa3",
+        "libc.so.6+0x129c6b"
+      ]
+    },
+    {
+      "lwp": 28304,
+      "frames": [
+        "libc.so.6+0x98d71",
+        "libc.so.6+0x9bc8d",
+        "libjvm.so+0xe43ebb",
+        "libjvm.so+0xde53f8",
+        "libjvm.so+0xf0ae63",
+        "libjvm.so+0xa02867",
+        "libjvm.so+0x106219e",
+        "libjvm.so+0xe37825",
+        "libc.so.6+0x9caa3",
+        "libc.so.6+0x129c6b"
+      ]
+    },
+    {
+      "lwp": 28303,
+      "frames": [
+        "libc.so.6+0x98d71",
+        "libc.so.6+0xa4fb7",
+        "libjvm.so+0xefd991",
+        "libjvm.so+0xf2b2db",
+        "libjvm.so+0xe28734",
+        "libjvm.so+0xa02867",
+        "libjvm.so+0x106219e",
+        "libjvm.so+0xe37825",
+        "libc.so.6+0x9caa3",
+        "libc.so.6+0x129c6b"
+      ]
+    },
+    {
+      "lwp": 28302,
+      "frames": [
+        "libc.so.6+0x98d71",
+        "libc.so.6+0x9b7ec",
+        "libjvm.so+0xe4370a",
+        "libjvm.so+0xe0f953",
+        "libjvm.so+0x10106ea",
+        "libjvm.so+0xae8334",
+        "void java.lang.Object.wait0(long)+0 in Object.java:0",
+        "void java.lang.Object.wait(long)+13 in Object.java:391",
+        "void java.lang.Object.wait()+0 in Object.java:353",
+        "java.lang.ref.Reference java.lang.ref.ReferenceQueue.remove0()+2 in ReferenceQueue.java:137",
+        "java.lang.ref.Reference java.lang.ref.ReferenceQueue.remove()+1 in ReferenceQueue.java:215",
+        "void java.lang.ref.Finalizer$FinalizerThread.run()+7 in Finalizer.java:165",
+        "StubRoutines (initial stubs)+0 in :0",
+        "libjvm.so+0x9e8b5f",
+        "libjvm.so+0x9ea4ae",
+        "libjvm.so+0xadf78b",
+        "libjvm.so+0xa02867",
+        "libjvm.so+0x106219e",
+        "libjvm.so+0xe37825",
+        "libc.so.6+0x9caa3",
+        "libc.so.6+0x129c6b"
+      ]
+    },
+    {
+      "lwp": 28301,
+      "frames": [
+        "libc.so.6+0x98d71",
+        "libc.so.6+0x9b7ec",
+        "libjvm.so+0xe43f4b",
+        "libjvm.so+0xde547d",
+        "libjvm.so+0xae5aa1",
+        "void java.lang.ref.Reference.waitForReferencePendingList()+0 in Reference.java:0",
+        "void java.lang.ref.Reference.processPendingReferences()+0 in Reference.java:240",
+        "void java.lang.ref.Reference$ReferenceHandler.run()+0 in Reference.java:202",
+        "StubRoutines (initial stubs)+0 in :0",
+        "libjvm.so+0x9e8b5f",
+        "libjvm.so+0x9ea4ae",
+        "libjvm.so+0xadf78b",
+        "libjvm.so+0xa02867",
+        "libjvm.so+0x106219e",
+        "libjvm.so+0xe37825",
+        "libc.so.6+0x9caa3",
+        "libc.so.6+0x129c6b"
+      ]
+    },
+    {
+      "lwp": 28300,
+      "frames": [
+        "libc.so.6+0x98d71",
+        "libc.so.6+0x9b7ec",
+        "libjvm.so+0xe43f4b",
+        "libjvm.so+0xde53f8",
+        "libjvm.so+0x110471c",
+        "libjvm.so+0x1105087",
+        "libjvm.so+0x106219e",
+        "libjvm.so+0xe37825",
+        "libc.so.6+0x9caa3",
+        "libc.so.6+0x129c6b"
+      ]
+    },
+    {
+      "lwp": 28299,
+      "frames": [
+        "libc.so.6+0x98d71",
+        "libc.so.6+0x9bc8d",
+        "libjvm.so+0xe43ebb",
+        "libjvm.so+0xde53f8",
+        "libjvm.so+0xe02fea",
+        "libjvm.so+0xe03100",
+        "libjvm.so+0x106219e",
+        "libjvm.so+0xe37825",
+        "libc.so.6+0x9caa3",
+        "libc.so.6+0x129c6b"
+      ]
+    },
+    {
+      "lwp": 28294,
+      "frames": [
+        "libc.so.6+0x98d71",
+        "libc.so.6+0x9bc8d",
+        "libjvm.so+0xe43ebb",
+        "libjvm.so+0xde53f8",
+        "libjvm.so+0x9161a5",
+        "libjvm.so+0x91659f",
+        "libjvm.so+0x72737a",
+        "libjvm.so+0x106219e",
+        "libjvm.so+0xe37825",
+        "libc.so.6+0x9caa3",
+        "libc.so.6+0x129c6b"
+      ]
+    },
+    {
+      "lwp": 28293,
+      "frames": [
+        "libc.so.6+0x98d71",
+        "libc.so.6+0xa4fb7",
+        "libjvm.so+0xefd991",
+        "libjvm.so+0x113abca",
+        "libjvm.so+0x106219e",
+        "libjvm.so+0xe37825",
+        "libc.so.6+0x9caa3",
+        "libc.so.6+0x129c6b"
+      ]
+    },
+    {
+      "lwp": 28292,
+      "frames": [
+        "libc.so.6+0x98d71",
+        "libc.so.6+0x9b7ec",
+        "libjvm.so+0xe43f4b",
+        "libjvm.so+0xde53f8",
+        "libjvm.so+0x8a9dba",
+        "libjvm.so+0x72737a",
+        "libjvm.so+0x106219e",
+        "libjvm.so+0xe37825",
+        "libc.so.6+0x9caa3",
+        "libc.so.6+0x129c6b"
+      ]
+    },
+    {
+      "lwp": 28291,
+      "frames": [
+        "libc.so.6+0x98d71",
+        "libc.so.6+0xa4fb7",
+        "libjvm.so+0xefd991",
+        "libjvm.so+0x113abca",
+        "libjvm.so+0x106219e",
+        "libjvm.so+0xe37825",
+        "libc.so.6+0x9caa3",
+        "libc.so.6+0x129c6b"
+      ]
+    },
+    {
+      "lwp": 28290,
+      "frames": [
+        "libc.so.6+0x98d71",
+        "libc.so.6+0x9b7ec",
+        "libjvm.so+0xe43f4b",
+        "libjvm.so+0xde53f8",
+        "libjvm.so+0x89f269",
+        "libjvm.so+0x72737a",
+        "libjvm.so+0x106219e",
+        "libjvm.so+0xe37825",
+        "libc.so.6+0x9caa3",
+        "libc.so.6+0x129c6b"
+      ]
+    },
+    {
+      "lwp": 28289,
+      "frames": [
+        "libc.so.6+0x98d71",
+        "libc.so.6+0xa4fb7",
+        "libjvm.so+0xefd991",
+        "libjvm.so+0x113abca",
+        "libjvm.so+0x106219e",
+        "libjvm.so+0xe37825",
+        "libc.so.6+0x9caa3",
+        "libc.so.6+0x129c6b"
+      ]
+    },
+    {
+      "lwp": 28288,
+      "frames": [
+        "vtable chunks+0 in :0",
+        "void Prof2.main(java.lang.String[])+8 in Prof2.java:16",
+        "StubRoutines (initial stubs)+0 in :0",
+        "libjvm.so+0x9e8b5f",
+        "libjvm.so+0xab6cd2",
+        "libjvm.so+0xab993e",
+        "libjli.so+0x3b79",
+        "libjli.so+0x4bff",
+        "libjli.so+0x8188",
+        "libc.so.6+0x9caa3",
+        "libc.so.6+0x129c6b"
+      ]
+    }
+  ],
+  "modules": [
+    {
+      "ref": "911511065ea1603312a6f671ee5484f9c5a0d5e83a32280440ad74507c564f1a",
+      "local-path": "/home/ubuntu/jdk-26/lib/libjimage.so"
+    },
+    {
+      "ref": "92dcea07a5b11d939c22a96131d3fbb995e0a84a4d02db7d799bf357689cd794",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libpthread.so.0"
+    },
+    {
+      "ref": "850b46fd4f4478060fc106f4d1dc4aa35c969eb5c9bd98aaf64dc6cb3d6a5e32",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libdl.so.2"
+    },
+    {
+      "ref": "1cd555ac46b7887edeaf3c42aac5408c8135e52f6b37870da2cf82d5fe14e829",
+      "local-path": "/usr/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2"
+    },
+    {
+      "ref": "4970ab7d350b1de61085e816e00f931f7aa6354a83d6abbde46826ee9a334eea",
+      "local-path": "/home/ubuntu/jdk-26/lib/server/libjvm.so"
+    },
+    {
+      "ref": "1b87a1a50b496cfead2b0ad134c2ff536705c82608db240c7e8aa48d6c0e4217",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libm.so.6"
+    },
+    {
+      "ref": "9d1cefae4c0e4995cc35ea3195f805454b2d59a27ad15397a1096e735d341faf",
+      "local-path": "/usr/lib/x86_64-linux-gnu/librt.so.1"
+    },
+    {
+      "ref": "9b64150b28505a33d6bc3ecf709c279f6de97a1c184dbda65d06ee4537f6d286",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libz.so.1.3"
+    },
+    {
+      "ref": "a89bc1d2b4b95774da97f32c78720a5778c6a76cb7a5dcda90275cdd4d460f4d",
+      "local-path": "/home/ubuntu/jdk-26/lib/libjli.so"
+    },
+    {
+      "ref": "8e459e410fbf3825894802e3899367e1fcb0adb6aa6e919bf7c333b405645471",
+      "local-path": "/home/ubuntu/jdk-26/bin/java"
+    },
+    {
+      "ref": "814a1fdeb48b8dd0a9bf54f2a122a93658fb4866783d1d7d693da71fb51de9f7",
+      "local-path": "/home/ubuntu/jdk-26/lib/libsimdsort.so"
+    },
+    {
+      "ref": "d8db8739a1633c972cec6a4fe0566bdcec6fd088f98723492ab0361f66238f75",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libc.so.6"
+    },
+    {
+      "ref": "ca8bb944728bfb437f812d68de480e34fe333abe5ea99ccc46b37f0c899edba3",
+      "local-path": "/home/ubuntu/jdk-26/lib/libjava.so"
+    }
+  ]
+}

--- a/tools/coredump/testdata/amd64/java26-prologue-epilogue.json
+++ b/tools/coredump/testdata/amd64/java26-prologue-epilogue.json
@@ -1,0 +1,317 @@
+{
+  "coredump-ref": "708cbf9b57c22025f7479adab562fb4c422053d41ad00cb13f2d7f13bd5e37ae",
+  "threads": [
+    {
+      "lwp": 28749,
+      "frames": [
+        "libc.so.6+0x11b4fd",
+        "gdb+0x7849dd",
+        "gdb+0x7854f7",
+        "gdb+0x3d3ea9",
+        "gdb+0x3d6f04",
+        "gdb+0x11ddab",
+        "libc.so.6+0x2a1c9",
+        "libc.so.6+0x2a28a",
+        "gdb+0x12c1f4"
+      ]
+    },
+    {
+      "lwp": 28758,
+      "frames": [
+        "libc.so.6+0x98d71",
+        "libc.so.6+0x9b7ec",
+        "gdb+0x790f5a",
+        "libstdc++.so.6.0.33+0xecdb3",
+        "libc.so.6+0x9caa3",
+        "libc.so.6+0x129c6b"
+      ]
+    },
+    {
+      "lwp": 28757,
+      "frames": [
+        "libc.so.6+0x98d71",
+        "libc.so.6+0x9b7ec",
+        "gdb+0x790f5a",
+        "libstdc++.so.6.0.33+0xecdb3",
+        "libc.so.6+0x9caa3",
+        "libc.so.6+0x129c6b"
+      ]
+    },
+    {
+      "lwp": 28756,
+      "frames": [
+        "libc.so.6+0x98d71",
+        "libc.so.6+0x9b7ec",
+        "gdb+0x790f5a",
+        "libstdc++.so.6.0.33+0xecdb3",
+        "libc.so.6+0x9caa3",
+        "libc.so.6+0x129c6b"
+      ]
+    },
+    {
+      "lwp": 28755,
+      "frames": [
+        "libc.so.6+0x98d71",
+        "libc.so.6+0x9b7ec",
+        "gdb+0x790f5a",
+        "libstdc++.so.6.0.33+0xecdb3",
+        "libc.so.6+0x9caa3",
+        "libc.so.6+0x129c6b"
+      ]
+    },
+    {
+      "lwp": 28754,
+      "frames": [
+        "libc.so.6+0x98d71",
+        "libc.so.6+0x9b7ec",
+        "gdb+0x790f5a",
+        "libstdc++.so.6.0.33+0xecdb3",
+        "libc.so.6+0x9caa3",
+        "libc.so.6+0x129c6b"
+      ]
+    },
+    {
+      "lwp": 28753,
+      "frames": [
+        "libc.so.6+0x98d71",
+        "libc.so.6+0x9b7ec",
+        "gdb+0x790f5a",
+        "libstdc++.so.6.0.33+0xecdb3",
+        "libc.so.6+0x9caa3",
+        "libc.so.6+0x129c6b"
+      ]
+    },
+    {
+      "lwp": 28752,
+      "frames": [
+        "libc.so.6+0x98d71",
+        "libc.so.6+0x9b7ec",
+        "gdb+0x790f5a",
+        "libstdc++.so.6.0.33+0xecdb3",
+        "libc.so.6+0x9caa3",
+        "libc.so.6+0x129c6b"
+      ]
+    },
+    {
+      "lwp": 28751,
+      "frames": [
+        "libc.so.6+0x98d71",
+        "libc.so.6+0x9b7ec",
+        "gdb+0x790f5a",
+        "libstdc++.so.6.0.33+0xecdb3",
+        "libc.so.6+0x9caa3",
+        "libc.so.6+0x129c6b"
+      ]
+    }
+  ],
+  "modules": [
+    {
+      "ref": "022943b3b11c860b049bce41342f1c2594941b7b401d95dfdf235521099fee08",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libcom_err.so.2.1"
+    },
+    {
+      "ref": "398c6d2025210279f4c7413ebdb7f4c63bc5afda5ec3b1ccc58885a65acc2b78",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libnghttp2.so.14.26.0"
+    },
+    {
+      "ref": "2156351fa3dedd04a7381c6ac7a8a26efa2d6fb08b80f8a2d644ccdd653710ae",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libmpfr.so.6.2.1"
+    },
+    {
+      "ref": "5bf46ff3e0fb33f25ff7cd98c877a45dbaf423242904a7eb485173f3fed91ca6",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libbabeltrace.so.1.0.0"
+    },
+    {
+      "ref": "0a079f958147699f7bb5bf228406a5d878dc2387fe9cdc5cce6f3e35e20380fc",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libreadline.so.8.2"
+    },
+    {
+      "ref": "a91ead095d2c80520c55a89057bbe10b031a075340442e63f44b310f93883a1b",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libbrotlicommon.so.1.1.0"
+    },
+    {
+      "ref": "ae6c5a9aecc249fc66e03c16ec6c4385d09d7e12e0ea7694bb831ab4fee8133c",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libpsl.so.5.3.4"
+    },
+    {
+      "ref": "9be84101980765fbf67430ca573b648406e68157ef022420e41b17e131904d91",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libssh.so.4.9.6"
+    },
+    {
+      "ref": "42467d0dbcc0a6c9e0a31f05a5944095504ce98f093c3fe0825f0a1533fa8207",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libglib-2.0.so.0.8000.0"
+    },
+    {
+      "ref": "6e632fd9a3125db60bbc623719bbc17b0470330321c5b1c57f1ff7190e5551ad",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libidn2.so.0.4.0"
+    },
+    {
+      "ref": "1b87a1a50b496cfead2b0ad134c2ff536705c82608db240c7e8aa48d6c0e4217",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libm.so.6"
+    },
+    {
+      "ref": "f96cda97eecdc05d36923d7a52d2119297c12904e321a40490a68f7b2c50394c",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libpython3.12.so.1.0"
+    },
+    {
+      "ref": "c6b469a006685ebf2075e200180c3b21f41b88ad722c5697d736ea558cfe3ea1",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libp11-kit.so.0.3.1"
+    },
+    {
+      "ref": "a0f410ad093236856eee59c4ff2838dc04d932ea0993400f23ed77d67d85af34",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libsasl2.so.2.0.25"
+    },
+    {
+      "ref": "59994414d0cdec4f678ef91eaaafc44b26b00bca507e4cc7978caaf79f584173",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libtasn1.so.6.6.3"
+    },
+    {
+      "ref": "c3c606139d4f7776efa4dbd4a6b62e30c916b07a0cafd8c3ef173d6f093607e3",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libhogweed.so.6.8"
+    },
+    {
+      "ref": "64d8a5019d4c294b89fde1193343ea324bbd8603652554e5545f0a01595fa2c5",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libbrotlidec.so.1.1.0"
+    },
+    {
+      "ref": "b7ae1a5a5702267e1612599335a5ece68093be99c13b394d55f9a782c390413e",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libgnutls.so.30.37.1"
+    },
+    {
+      "ref": "d5a30761bb7e8eadc3345ce3cfbb7567df86159b93e8e1700fd6d34505ad2e20",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libbabeltrace-ctf.so.1.0.0"
+    },
+    {
+      "ref": "a9793942a8a5f6f4d0f523ef9e0a5be4f0033f2c6c28520cd2b4e706d53c6e17",
+      "local-path": "/usr/lib/x86_64-linux-gnu/liblzma.so.5.4.5"
+    },
+    {
+      "ref": "1cd555ac46b7887edeaf3c42aac5408c8135e52f6b37870da2cf82d5fe14e829",
+      "local-path": "/usr/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2"
+    },
+    {
+      "ref": "720f3720d0a0891042b0773d3218163a8e050e26c33744dc173086c5db25f9d6",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libcurl-gnutls.so.4.8.0"
+    },
+    {
+      "ref": "f48214417757f18793ed6e180cc14ee1d6f04252a518fc7270e8ca1d0b4260fe",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libkeyutils.so.1.10"
+    },
+    {
+      "ref": "e00576d71d81d3ba0cfa4903c835a44a8723aac96f72f79ff75200b4cff9071b",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libpcre2-8.so.0.11.2"
+    },
+    {
+      "ref": "d93224d2b0dab4247598be683adca02f5cf00586f99c187579cd7e92058fb7cb",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libgcc_s.so.1"
+    },
+    {
+      "ref": "0ccdfb6d6f5c039465f6d002cf7e4c072d48ac6a2cffc8dd6c748dec31592804",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libgmp.so.10.5.0"
+    },
+    {
+      "ref": "8e1ef5a40f7b0d5b0fbcd6e4f28dd50b263650338a2bb72503be34632f3629d6",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libkrb5support.so.0.1"
+    },
+    {
+      "ref": "b9a20df712d206654477c079f03b568276933e91cbe237e62af791f0f3ab8d8b",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libgssapi_krb5.so.2.2"
+    },
+    {
+      "ref": "248c989360783cdc52f3659921de852c2efcc2097253ce58e34443f856412814",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libelf-0.190.so"
+    },
+    {
+      "ref": "7a73ccfb5cb9fe03ffa3710cf6fcae518af48fb71696957f5a334c802e8f42a5",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libsource-highlight.so.4.0.1"
+    },
+    {
+      "ref": "ada59231b9ce983951fdd3425ebb4c138fa473b7470d5bc9d9285a3f8687f801",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libdebuginfod-0.190.so"
+    },
+    {
+      "ref": "4763f3f4e0c4f776ec0d6bda54374c0d86bab570259501e50bc492a4fe9cf978",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libipt.so.2.0.6"
+    },
+    {
+      "ref": "61f693cd7f8e55ad3ab518b20a00c01adb46ef829cf90773c97615a73f99e09b",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libtinfo.so.6.4"
+    },
+    {
+      "ref": "a7d7897c415473e5a4e393fe1a6faf5828c73e06ed2eb6d11648a2cef4ea3552",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libncursesw.so.6.4"
+    },
+    {
+      "ref": "2c4c310ff85793ed0edcff9d548a6a73041f68fd0eb6fa998388bb43787036e3",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libresolv.so.2"
+    },
+    {
+      "ref": "d6fc1bc9de29c55fc905f77edba1ccc7c7a50b32bd2bb9086b0d0b00104eafc4",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libcrypto.so.3"
+    },
+    {
+      "ref": "8394027f2be7c2cc7b2da4797476a8b688a21f75ee231941fa2df8d00ba79d08",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libk5crypto.so.3.1"
+    },
+    {
+      "ref": "ddf14275b1fb70ba06510094071adcc1462e675f15ae6cdcadbf40c1dabe5a03",
+      "local-path": "/usr/lib/x86_64-linux-gnu/liblber.so.2.0.200"
+    },
+    {
+      "ref": "a9829b999c95452eb0a34cc7b5349427b76dbf3e5d5c8672a5ca69e454c1b151",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libldap.so.2.0.200"
+    },
+    {
+      "ref": "15a2a75e8c437b9c99971b5ee10278ab110beef1a56d1d9e5d6759ea140e98ac",
+      "local-path": "/usr/lib/x86_64-linux-gnu/librtmp.so.1"
+    },
+    {
+      "ref": "d8db8739a1633c972cec6a4fe0566bdcec6fd088f98723492ab0361f66238f75",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libc.so.6"
+    },
+    {
+      "ref": "a43c43c2fbb643f42572577b6c2514905804f963d186d4d630e184c4015e68a7",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libxxhash.so.0.8.2"
+    },
+    {
+      "ref": "7bcf825cd449892db5105ad2aed91dcf94a27b796426600c765720c584c54dd1",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libunistring.so.5.0.0"
+    },
+    {
+      "ref": "f0068d3b418ae039c309574b33901b82404025eb46c2e983246b9c3976ba7e83",
+      "local-path": "/usr/bin/gdb"
+    },
+    {
+      "ref": "52c143c9c77a223a4dac5449eac41fd2490e37c8a30430f1559c1421f4f8ed73",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libkrb5.so.3.3"
+    },
+    {
+      "ref": "00f593fe192f2851b8ce23b25cec2488d769beb5a8f63e8c9e563071e1075153",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libffi.so.8.1.4"
+    },
+    {
+      "ref": "1fd75fe70354a416d75aef22bcae68c47bd25d20e2d0568c30b1a9838cf62f11",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.33"
+    },
+    {
+      "ref": "fdbd3ec8f62e02fdf12e2fbfd2ba080ed0122a2f0a56a343061a6743f1a56568",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libuuid.so.1.3.0"
+    },
+    {
+      "ref": "c42ff317838b4b4639e2ea801905f0317177c6df7e31b2f0d0240e3c3ac0cfde",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libexpat.so.1.9.1"
+    },
+    {
+      "ref": "0a2128bc10841fb29e76d08d945864dfb0b6a66da5df6df5d8299197439e54bb",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libzstd.so.1.5.5"
+    },
+    {
+      "ref": "a245ed916229583d6fe0b07657b3ed945bc148c28cc08b5266295f620d2b91cc",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libnettle.so.8.8"
+    },
+    {
+      "ref": "9b64150b28505a33d6bc3ecf709c279f6de97a1c184dbda65d06ee4537f6d286",
+      "local-path": "/usr/lib/x86_64-linux-gnu/libz.so.1.3"
+    }
+  ]
+}


### PR DESCRIPTION
### What does this PR do?

Adds JDK 26 support to the HotSpot JVM interpreter in the eBPF profiler. It handles breaking changes in the JDK 26 nmethod VM struct by adding new field mappings and adjusting immutable data size calculation to account for the new ref count trailer.

Key changes in interpreter/hotspot/:
  - `data.go`: Added `ImmutableDataRefCountOff` field (JDK 26+), added `_deopt_handler_entry_offset` as an alias for `DeoptimizeOffset`.
  - `instance.go`: When `_immutable_data_ref_count_offset` is present, use it to cap the immutable data region size.
  - `hotspot.go`: Documented JDK 26 changes in the version history comment block.

### Motivation

JDK 26 introduces several changes in the HotSpot VM internals (renamed/removed fields in `nmethod`, new `_immutable_data_ref_count_offset` field, renumbered `PcDesc` flags). Without these fixes, the eBPF profiler cannot correctly unwind Java stacks on JDK 26.

The objective is to identify the breaking changes introduced by this new JDK version and ensure they are properly handled.

### Describe how you validated your changes

### Additional Notes