### PR TITLE
Tag old datadog HEAD before rebase to preserve go.mod references

### DIFF
--- a/.github/workflows/rebase-on-upstream.yml
+++ b/.github/workflows/rebase-on-upstream.yml
@@ -67,6 +67,17 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Tag old datadog HEAD
+        run: |
+          old_sha=$(git rev-parse origin/datadog)
+          if git tag --points-at "$old_sha" | grep -q .; then
+            echo "Tag already exists for $old_sha, skipping"
+          else
+            tag_name="refs-${old_sha:0:12}"
+            git tag -a "$tag_name" "$old_sha" -m "Preserve old datadog HEAD before rebase"
+            git push origin "$tag_name"
+          fi
+
       - name: Rewrite datadog branch
         run: |
           git checkout datadog


### PR DESCRIPTION
Force-pushing the datadog branch makes old commit hashes unreachable, breaking go.mod replace directives that reference them by pseudo-version.

@DataDog/profiling-full-host 