### PR TITLE
process: replace fileToMapping cache with OpenELFMapping

### DIFF
--- a/process/coredump.go
+++ b/process/coredump.go
@@ -308,6 +308,11 @@ func (cd *CoredumpProcess) CalculateMappingFileID(m *RawMapping) (libpf.FileID, 
 	return libpf.FileIDFromBytes(h.Sum(nil))
 }
 
+// OpenELFMapping implements the Process interface. Implemented as fallback to OpenELF.
+func (cd *CoredumpProcess) OpenELFMapping(m *RawMapping) (*pfelf.File, error) {
+	return cd.OpenELF(m.Path)
+}
+
 // OpenELF implements the ELFOpener and Process interfaces.
 func (cd *CoredumpProcess) OpenELF(path string) (*pfelf.File, error) {
 	// Fallback to directly returning the data from coredump. This comes with caveats:

--- a/process/process.go
+++ b/process/process.go
@@ -60,8 +60,6 @@ type systemProcess struct {
 
 	mainThreadExit bool
 	remoteMemory   remotememory.RemoteMemory
-
-	fileToMapping map[string]*RawMapping
 }
 
 var _ Process = &systemProcess{}
@@ -394,20 +392,13 @@ func (sp *systemProcess) IterateMappings(callback func(m RawMapping) bool) (uint
 	}
 	defer mapsFile.Close()
 
-	fileToMapping := make(map[string]*RawMapping)
 	gotMappings := false
-
-	collectForOpenELF := func(m RawMapping) bool {
+	trackedCallback := func(m RawMapping) bool {
 		gotMappings = true
-		if m.IsExecutable() || m.IsVDSO() {
-			stored := m
-			stored.Path = libpf.Intern(m.Path).String()
-			fileToMapping[stored.Path] = &stored
-		}
 		return callback(m)
 	}
 
-	numParseErrors, err := iterateMappings(mapsFile, collectForOpenELF)
+	numParseErrors, err := iterateMappings(mapsFile, trackedCallback)
 	if err != nil {
 		return numParseErrors, err
 	}
@@ -437,13 +428,12 @@ func (sp *systemProcess) IterateMappings(callback func(m RawMapping) bool) (uint
 			return numParseErrors, ErrNoMappings
 		}
 		defer mapsFileAlt.Close()
-		numParseErrors, err := iterateMappings(mapsFileAlt, collectForOpenELF)
+		numParseErrors, err := iterateMappings(mapsFileAlt, trackedCallback)
 		if err != nil || !gotMappings {
 			return numParseErrors, ErrNoMappings
 		}
 	}
 
-	sp.fileToMapping = fileToMapping
 	return numParseErrors, nil
 }
 
@@ -521,23 +511,28 @@ func (sp *systemProcess) CalculateMappingFileID(m *RawMapping) (libpf.FileID, er
 	return libpf.FileIDFromExecutableFile(sp.getMappingFile(m))
 }
 
-func (sp *systemProcess) OpenELF(file string) (*pfelf.File, error) {
-	// Always open via map_files as it can open deleted files if available.
+func (sp *systemProcess) OpenELFMapping(m *RawMapping) (*pfelf.File, error) {
+	// Open ELF via map_files as it can open deleted files if available.
 	// No fallback is attempted:
-	// - if the process exited, the fallback will error also (/proc/>PID> is gone)
+	// - if the process exited, the fallback will error also (/proc/<PID> is gone)
 	// - if the error is due to ELF content, same error will occur in both cases
 	// - if the process unmapped the ELF, its data is no longer needed
-	if m, ok := sp.fileToMapping[file]; ok {
-		if m.IsVDSO() {
-			vdso, err := sp.extractMapping(m)
-			if err != nil {
-				return nil, fmt.Errorf("failed to extract VDSO: %v", err)
-			}
-			return pfelf.NewFile(vdso, 0, false)
+	if m.IsVDSO() {
+		vdso, err := sp.extractMapping(m)
+		if err != nil {
+			return nil, fmt.Errorf("failed to extract VDSO: %v", err)
 		}
-		return pfelf.Open(sp.getMappingFile(m))
+		return pfelf.NewFile(vdso, 0, false)
 	}
+	if !m.IsFileBacked() {
+		return nil, fmt.Errorf("mapping at %#x has no backing file", m.Vaddr)
+	}
+	return pfelf.Open(sp.getMappingFile(m))
+}
 
-	// Fall back to opening the file using the process specific root
+func (sp *systemProcess) OpenELF(file string) (*pfelf.File, error) {
+	// Open the file using the process-specific root. Callers that have a
+	// RawMapping should use OpenELFMapping instead, which can open deleted
+	// or replaced files via /proc/<pid>/map_files.
 	return pfelf.Open(path.Join("/proc", strconv.Itoa(int(sp.pid)), "root", file))
 }

--- a/process/types.go
+++ b/process/types.go
@@ -125,8 +125,8 @@ type ProcessMeta struct {
 
 // Process is the interface to inspect ELF coredump/process.
 // The current implementations do not allow concurrent access to this interface
-// from different goroutines. As an exception the ELFOpener and the returned
-// GetRemoteMemory object are safe for concurrent use.
+// from different goroutines. As an exception ELFOpener, OpenELFMapping, and
+// the returned GetRemoteMemory object are safe for concurrent use.
 type Process interface {
 	// PID returns the process identifier.
 	PID() libpf.PID
@@ -156,6 +156,11 @@ type Process interface {
 
 	// OpenMappingFile returns ReadAtCloser accessing the backing file of the mapping.
 	OpenMappingFile(*RawMapping) (ReadAtCloser, error)
+
+	// OpenELFMapping opens a memory mapping as an ELF file. The mapping must
+	// originate from this Process (via IterateMappings), passing a foreign
+	// mapping has undefined results.
+	OpenELFMapping(*RawMapping) (*pfelf.File, error)
 
 	// GetMappingFileLastModifed returns the timestamp when the backing file was last modified
 	// or zero if an error occurs or mapping file is not accessible via filesystem.

--- a/processmanager/processinfo.go
+++ b/processmanager/processinfo.go
@@ -352,8 +352,28 @@ func (pm *ProcessManager) processRemovedInterpreters(pid libpf.PID,
 
 var errInvalidVirtualAddress = errors.New("invalid ELF virtual address")
 
+// mappingELFOpener wraps a process.Process so that opens of the bound
+// mapping's path go through OpenELFMapping (which handles VDSO and uses
+// /proc/<pid>/map_files for deleted-file safety). All other paths
+// (e.g. .gnu_debuglink targets) fall through to the underlying OpenELF.
+//
+// Routing relies on pfelf.Reference invoking OpenELF with the original
+// m.Path string for the primary file. synchronizeMappings interns m.Path
+// before constructing the Reference, so it's safe to keep mapping.
+type mappingELFOpener struct {
+	pr      process.Process
+	mapping *process.RawMapping
+}
+
+func (o *mappingELFOpener) OpenELF(file string) (*pfelf.File, error) {
+	if file == o.mapping.Path {
+		return o.pr.OpenELFMapping(o.mapping)
+	}
+	return o.pr.OpenELF(file)
+}
+
 func (pm *ProcessManager) newFrameMapping(pr process.Process, m *process.RawMapping) (libpf.FrameMapping, error) {
-	elfRef := pfelf.NewReference(m.Path, pr)
+	elfRef := pfelf.NewReference(m.Path, &mappingELFOpener{pr: pr, mapping: m})
 	defer elfRef.Close()
 
 	info := pm.getELFInfo(pr, m, elfRef)

--- a/tools/coredump/new.go
+++ b/tools/coredump/new.go
@@ -97,6 +97,10 @@ func (tc *trackedCoredump) OpenMappingFile(m *process.RawMapping) (process.ReadA
 	return tc.CoredumpProcess.OpenMappingFile(m)
 }
 
+func (tc *trackedCoredump) OpenELFMapping(m *process.RawMapping) (*pfelf.File, error) {
+	return tc.OpenELF(m.Path)
+}
+
 func (tc *trackedCoredump) OpenELF(fileName string) (*pfelf.File, error) {
 	if fileName != process.VdsoPathName {
 		f, err := pfelf.Open(path.Join(tc.prefix, fileName))

--- a/tools/coredump/storecoredump.go
+++ b/tools/coredump/storecoredump.go
@@ -49,6 +49,10 @@ func (scd *StoreCoredump) OpenMappingFile(m *process.RawMapping) (process.ReadAt
 	return scd.openFile(m.Path)
 }
 
+func (scd *StoreCoredump) OpenELFMapping(m *process.RawMapping) (*pfelf.File, error) {
+	return scd.OpenELF(m.Path)
+}
+
 func (scd *StoreCoredump) OpenELF(path string) (*pfelf.File, error) {
 	file, err := scd.openFile(path)
 	if err == nil {


### PR DESCRIPTION
Replace the `systemProcess.fileToMapping` map (populated as a side
effect of IterateMappings, then consulted by OpenELF) with an
explicit `OpenELFMapping(*RawMapping)` method on the Process
interface. The mapping is now passed directly, removing the temporal
coupling between the two methods and the path-keyed lookup.

In processmanager.newFrameMapping, a small `mappingELFOpener` adapter
routes opens of the bound mapping's path to `OpenELFMapping` while
forwarding everything else (e.g. .gnu_debuglink targets) to `OpenELF`.

This also fixes some issues with `fileToMapping`:
- The first iteration after process creation missed the map_files
  route because `sp.fileToMapping` was assigned only at the end of
  `IterateMappings` and subsequent iterations could use a stale
  RawMapping (from the previous iteration).
- Avoid path-keyed lookup that could pick the wrong file in some
  very rare cases (https://github.com/open-telemetry/opentelemetry-ebpf-profiler/issues/812).