### PR TITLE
fix: decrement HashmapPidPageToMappingInfo metric on processPIDExit

### DIFF
--- a/processmanager/ebpf/ebpf.go
+++ b/processmanager/ebpf/ebpf.go
@@ -640,7 +640,7 @@ func (impl *ebpfMapsImpl) UpdatePidPageMappingInfo(pid libpf.PID, prefix lpm.Pre
 
 // DeletePidPageMappingInfo removes the elements specified by prefixes from eBPF map
 // pid_page_to_mapping_info and returns the number of elements removed.
-func (impl *ebpfMapsImpl) DeletePidPageMappingInfo(pid libpf.PID, prefixes []lpm.Prefix) (int,
+func (impl *ebpfMapsImpl) DeletePidPageMappingInfo(pid libpf.PID, prefixes []lpm.Prefix) (uint64,
 	error,
 ) {
 	if impl.hasLPMTrieBatchOperations {
@@ -656,11 +656,11 @@ func (impl *ebpfMapsImpl) DeletePidPageMappingInfo(pid libpf.PID, prefixes []lpm
 	return impl.DeletePidPageMappingInfoSingle(pid, prefixes)
 }
 
-func (impl *ebpfMapsImpl) DeletePidPageMappingInfoSingle(pid libpf.PID, prefixes []lpm.Prefix) (int,
+func (impl *ebpfMapsImpl) DeletePidPageMappingInfoSingle(pid libpf.PID, prefixes []lpm.Prefix) (uint64,
 	error,
 ) {
 	cKey := &support.PIDPage{}
-	var deleted int
+	var deleted uint64
 	var combinedErrors error
 	for _, prefix := range prefixes {
 		*cKey = getPIDPageFromPrefix(pid, prefix)
@@ -674,7 +674,7 @@ func (impl *ebpfMapsImpl) DeletePidPageMappingInfoSingle(pid libpf.PID, prefixes
 	return deleted, combinedErrors
 }
 
-func (impl *ebpfMapsImpl) DeletePidPageMappingInfoBatch(pid libpf.PID, prefixes []lpm.Prefix) (int,
+func (impl *ebpfMapsImpl) DeletePidPageMappingInfoBatch(pid libpf.PID, prefixes []lpm.Prefix) (uint64,
 	error,
 ) {
 	// Prepare all keys based on the given prefixes.
@@ -685,7 +685,13 @@ func (impl *ebpfMapsImpl) DeletePidPageMappingInfoBatch(pid libpf.PID, prefixes 
 
 	deleted, err := impl.PidPageToMappingInfo.BatchDelete(
 		ptrCastMarshaler[support.PIDPage](cKeys), nil)
-	return deleted, impl.trackMapError(metrics.IDPidPageToMappingInfoBatchDelete, err)
+
+	// BatchDelete returns a count of deleted entries, so this should never happen.
+	if deleted < 0 {
+		err = errors.Join(err, fmt.Errorf("negative batch delete count: %d", deleted))
+		deleted = 0
+	}
+	return uint64(deleted), impl.trackMapError(metrics.IDPidPageToMappingInfoBatchDelete, err)
 }
 
 // LookupPidPageInformation returns the fileID and bias for a given pid and page combination from

--- a/processmanager/ebpfapi/ebpf.go
+++ b/processmanager/ebpfapi/ebpf.go
@@ -51,7 +51,7 @@ type EbpfHandler interface {
 
 	// DeletePidPageMappingInfo removes the elements specified by prefixes from eBPF map
 	// pid_page_to_mapping_info and returns the number of elements removed.
-	DeletePidPageMappingInfo(pid libpf.PID, prefixes []lpm.Prefix) (int, error)
+	DeletePidPageMappingInfo(pid libpf.PID, prefixes []lpm.Prefix) (uint64, error)
 
 	// CollectMetrics returns gathered errors for changes to eBPF maps.
 	CollectMetrics() []metrics.Metric

--- a/processmanager/processinfo.go
+++ b/processmanager/processinfo.go
@@ -318,7 +318,7 @@ func (pm *ProcessManager) processRemovedMapping(pid libpf.PID, m *Mapping) uint6
 
 	fileID := host.FileIDFromLibpf(mf.File.Value().FileID)
 	pm.eim.DecRef(fileID)
-	return uint64(deleted)
+	return deleted
 }
 
 // Caller is responsible to hold pm.mu write lock to avoid race conditions.
@@ -456,11 +456,11 @@ func (pm *ProcessManager) processPIDExit(pid libpf.PID) {
 		err = errors.Join(err, fmt.Errorf("failed to delete dummy prefix for PID %d: %v",
 			pid, err2))
 	}
-	pm.pidPageToMappingInfoSize -= uint64(deleted)
 
 	for idx := range info.mappings {
-		pm.processRemovedMapping(pid, &info.mappings[idx])
+		deleted += pm.processRemovedMapping(pid, &info.mappings[idx])
 	}
+	pm.pidPageToMappingInfoSize -= min(pm.pidPageToMappingInfoSize, deleted)
 	pm.processRemovedInterpreters(pid, libpf.Set[util.OnDiskFileIdentifier]{})
 }
 
@@ -651,7 +651,7 @@ func (pm *ProcessManager) SynchronizeProcess(pr process.Process) {
 	for _, m := range mpRemove {
 		numChanges += pm.processRemovedMapping(pid, m)
 	}
-	pm.pidPageToMappingInfoSize -= numChanges
+	pm.pidPageToMappingInfoSize -= min(pm.pidPageToMappingInfoSize, numChanges)
 	pm.mu.Lock()
 	pm.processRemovedInterpreters(pid, interpretersValid)
 	pm.mu.Unlock()

--- a/tools/coredump/ebpfmaps.go
+++ b/tools/coredump/ebpfmaps.go
@@ -234,9 +234,9 @@ func (emc *ebpfMapsCoredump) UpdatePidPageMappingInfo(pid libpf.PID, prefix lpm.
 		host.FileID(fileID), bias)
 }
 
-func (emc *ebpfMapsCoredump) DeletePidPageMappingInfo(pid libpf.PID, prefixes []lpm.Prefix) (int,
+func (emc *ebpfMapsCoredump) DeletePidPageMappingInfo(pid libpf.PID, prefixes []lpm.Prefix) (uint64,
 	error) {
-	var deleted int
+	var deleted uint64
 	for _, prefix := range prefixes {
 		if err := emc.DeletePidInterpreterMapping(pid, prefix); err != nil {
 			return deleted, err


### PR DESCRIPTION
## Summary
Recently, we observed some unusual behavior regarding the `HashmapPidPageToMappingInfo` metric.

<img width="4954" height="796" alt="image" src="https://github.com/user-attachments/assets/3d629e4f-d695-48b9-8d99-292d058a0da3" />


According to the graph, we reached 163M entries in the eBPF map at one point, which seems way too high. When inspecting the actual map with:

```bash
$ bpftool -j map show id 31184 

{"id":11696,"type":"lpm_trie","name":"pid_page_to_map","flags":1,"bytes_key":16,"bytes_value":16,"max_entries":1048576,"bytes_memlock":2120920,"frozen":0,"btf_id":99410}
```
We are supposed to have a maximum of ~1M entries, so this value is definitely off.


## Validating the changes
I tested by running both the unpatched and patched versions on separate nodes with identical workloads.

### Without fix

<img width="4042" height="660" alt="image" src="https://github.com/user-attachments/assets/3f46a905-3b19-4a89-9258-fa6561935bb0" />


### With fix

<img width="4882" height="658" alt="image" src="https://github.com/user-attachments/assets/25180a10-2f05-4046-9d09-4930bd638b11" />
