### PR TITLE
Fix go systemstack unwinding (#1452)

### DIFF
--- a/nativeunwind/elfunwindinfo/elfgopclntab.go
+++ b/nativeunwind/elfunwindinfo/elfgopclntab.go
@@ -31,10 +31,10 @@ var goFunctionsStopDelta = map[string]*sdtypes.UnwindInfo{
 	"runtime.mstart": &sdtypes.UnwindInfoStop, // topmost for the go runtime main stacks
 	"runtime.goexit": &sdtypes.UnwindInfoStop, // return address in all goroutine stacks
 
-	// stack switch functions that would need special handling for further unwinding.
-	// See PF-1101.
+	// systemstack preserves the frame pointer chain across
+	// the g0/user stack boundary, so standard FP unwinding traverses it naturally.
+	"runtime.systemstack": &sdtypes.UnwindInfoFramePointer,
 	"runtime.mcall":       &sdtypes.UnwindInfoStop,
-	"runtime.systemstack": &sdtypes.UnwindInfoStop,
 
 	// signal return frame
 	"runtime.sigreturn":            &sdtypes.UnwindInfoSignal,
@@ -737,6 +737,7 @@ func (ee *elfExtractor) parseGoPclntab() error {
 	// Get target machine architecture for the ELF file
 	arch := ee.file.Machine
 	defaultStrategy := strategyFramePointer
+	isFramePointerReliable := true
 	var parsePclntab func(deltas *sdtypes.StackDeltaArray, p pcval, s strategy) error
 
 	switch arch {
@@ -751,12 +752,14 @@ func (ee *elfExtractor) parseGoPclntab() error {
 		case go1_2, go1_16, go1_18:
 			// Magic indicates old Go with broken arm64 frame pointers
 			defaultStrategy = strategyDeltasWithFrame
+			isFramePointerReliable = false
 		case go1_20:
 			// Ambiguous regarding if frame pointer is kept correctly.
 			// Take the slow path of resolving Go version.
 			goVer, err := ee.file.GoVersion()
 			if err != nil || version.Compare(goVer, "go1.21rc1") < 0 {
 				defaultStrategy = strategyDeltasWithFrame
+				isFramePointerReliable = false
 			}
 		}
 	default:
@@ -775,9 +778,13 @@ func (ee *elfExtractor) parseGoPclntab() error {
 		// First, check for functions with special handling.
 		funcName := getString(g.funcnametab, int(fun.nameOff))
 		if info, found := goFunctionsStopDelta[funcName]; found {
+			unwindInfo := *info
+			if unwindInfo == sdtypes.UnwindInfoFramePointer && !isFramePointerReliable {
+				unwindInfo = sdtypes.UnwindInfoStop
+			}
 			ee.deltas.Add(sdtypes.StackDelta{
 				Address: uint64(funcPc),
-				Info:    *info,
+				Info:    unwindInfo,
 			})
 			continue
 		}

--- a/tools/coredump/testdata/amd64/go-systemstack.json
+++ b/tools/coredump/testdata/amd64/go-systemstack.json
@@ -1,0 +1,86 @@
+{
+  "coredump-ref": "f5babed1a9bbeff812351bf68b8612561f991c2a6b56afdf4be8da5b50e87011",
+  "threads": [
+    {
+      "lwp": 8333,
+      "frames": [
+        "runtime.tracebackPCs+0 in /home/ubuntu/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.0.linux-amd64/src/runtime/traceback.go:628",
+        "runtime.callers.func1+0 in /home/ubuntu/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.0.linux-amd64/src/runtime/traceback.go:1100",
+        "runtime.systemstack+0 in /home/ubuntu/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.0.linux-amd64/src/runtime/asm_amd64.s:517",
+        "runtime.callers+0 in /home/ubuntu/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.0.linux-amd64/src/runtime/traceback.go:1097",
+        "main.main+0 in /home/ubuntu/ebpf/tools/coredump/testsources/go/systemstack/main.go:16",
+        "runtime.main+0 in /home/ubuntu/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.0.linux-amd64/src/internal/runtime/atomic/types.go:194",
+        "runtime.goexit+0 in /home/ubuntu/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.0.linux-amd64/src/runtime/asm_amd64.s:1694"
+      ]
+    },
+    {
+      "lwp": 8339,
+      "frames": [
+        "runtime.futex+0 in /home/ubuntu/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.0.linux-amd64/src/runtime/sys_linux_amd64.s:558",
+        "runtime.futexsleep+0 in /home/ubuntu/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.0.linux-amd64/src/runtime/os_linux.go:76",
+        "runtime.notesleep+0 in /home/ubuntu/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.0.linux-amd64/src/runtime/lock_futex.go:48",
+        "runtime.templateThread+0 in /home/ubuntu/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.0.linux-amd64/src/runtime/lock_spinbit.go:152",
+        "runtime.mstart1+0 in /home/ubuntu/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.0.linux-amd64/src/runtime/proc.go:1928",
+        "runtime.mstart0+0 in /home/ubuntu/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.0.linux-amd64/src/runtime/proc.go:1890",
+        "runtime.mstart+0 in /home/ubuntu/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.0.linux-amd64/src/runtime/asm_amd64.s:396"
+      ]
+    },
+    {
+      "lwp": 8338,
+      "frames": [
+        "runtime.futex+0 in /home/ubuntu/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.0.linux-amd64/src/runtime/sys_linux_amd64.s:558",
+        "runtime.futexsleep+0 in /home/ubuntu/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.0.linux-amd64/src/runtime/os_linux.go:76",
+        "runtime.notesleep+0 in /home/ubuntu/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.0.linux-amd64/src/runtime/lock_futex.go:48",
+        "runtime.stopm+0 in /home/ubuntu/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.0.linux-amd64/src/runtime/proc.go:1961",
+        "runtime.startlockedm+0 in /home/ubuntu/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.0.linux-amd64/src/runtime/proc.go:3283",
+        "runtime.schedule+0 in /home/ubuntu/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.0.linux-amd64/src/runtime/proc.go:4128",
+        "runtime.park_m+0 in /home/ubuntu/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.0.linux-amd64/src/runtime/proc.go:4267",
+        "runtime.mcall+0 in /home/ubuntu/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.0.linux-amd64/src/runtime/asm_amd64.s:462"
+      ]
+    },
+    {
+      "lwp": 8337,
+      "frames": [
+        "runtime.futex+0 in /home/ubuntu/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.0.linux-amd64/src/runtime/sys_linux_amd64.s:558",
+        "runtime.futexsleep+0 in /home/ubuntu/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.0.linux-amd64/src/runtime/os_linux.go:76",
+        "runtime.notesleep+0 in /home/ubuntu/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.0.linux-amd64/src/runtime/lock_futex.go:48",
+        "runtime.stopm+0 in /home/ubuntu/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.0.linux-amd64/src/runtime/proc.go:1961",
+        "runtime.startlockedm+0 in /home/ubuntu/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.0.linux-amd64/src/runtime/proc.go:3283",
+        "runtime.schedule+0 in /home/ubuntu/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.0.linux-amd64/src/runtime/proc.go:4128",
+        "runtime.mstart1+0 in /home/ubuntu/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.0.linux-amd64/src/runtime/proc.go:1936",
+        "runtime.mstart0+0 in /home/ubuntu/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.0.linux-amd64/src/runtime/proc.go:1890",
+        "runtime.mstart+0 in /home/ubuntu/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.0.linux-amd64/src/runtime/asm_amd64.s:396"
+      ]
+    },
+    {
+      "lwp": 8336,
+      "frames": [
+        "runtime.futex+0 in /home/ubuntu/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.0.linux-amd64/src/runtime/sys_linux_amd64.s:558",
+        "runtime.futexsleep+0 in /home/ubuntu/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.0.linux-amd64/src/runtime/os_linux.go:76",
+        "runtime.notesleep+0 in /home/ubuntu/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.0.linux-amd64/src/runtime/lock_futex.go:48",
+        "runtime.stopm+0 in /home/ubuntu/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.0.linux-amd64/src/runtime/proc.go:1961",
+        "runtime.findRunnable+0 in /home/ubuntu/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.0.linux-amd64/src/runtime/proc.go:3374",
+        "runtime.schedule+0 in /home/ubuntu/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.0.linux-amd64/src/runtime/proc.go:4138",
+        "runtime.park_m+0 in /home/ubuntu/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.0.linux-amd64/src/runtime/proc.go:4267",
+        "runtime.mcall+0 in /home/ubuntu/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.0.linux-amd64/src/runtime/asm_amd64.s:462"
+      ]
+    },
+    {
+      "lwp": 8335,
+      "frames": [
+        "runtime.usleep+0 in /home/ubuntu/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.0.linux-amd64/src/runtime/sys_linux_amd64.s:135",
+        "runtime.sysmon+0 in /home/ubuntu/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.0.linux-amd64/src/runtime/proc.go:6234",
+        "runtime.sysmon+0 in /home/ubuntu/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.0.linux-amd64/src/runtime/proc.go:6234",
+        "runtime.mstart1+0 in /home/ubuntu/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.0.linux-amd64/src/runtime/proc.go:1928",
+        "runtime.mstart0+0 in /home/ubuntu/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.0.linux-amd64/src/runtime/proc.go:1890",
+        "runtime.mstart+0 in /home/ubuntu/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.0.linux-amd64/src/runtime/asm_amd64.s:396"
+      ]
+    }
+  ],
+  "modules": [
+    {
+      "ref": "f22ffd48283331543df3b65dde5e9f83fe955c29b3ce690e5390d9bc49d8133b",
+      "local-path": "/home/ubuntu/ebpf/test-systemstack"
+    }
+  ]
+}

--- a/tools/coredump/testdata/arm64/go-systemstack.json
+++ b/tools/coredump/testdata/arm64/go-systemstack.json
@@ -1,0 +1,95 @@
+{
+  "coredump-ref": "1bae7d343778a31cc6ccd7a1249e58a79abebf9e6d1d53d8cb105d1693d6090d",
+  "threads": [
+    {
+      "lwp": 6414,
+      "frames": [
+        "runtime.pcvalue+0 in /usr/local/go/src/runtime/symtab.go:1032",
+        "runtime.(*unwinder).resolveInternal+0 in /usr/local/go/src/runtime/traceback.go:326",
+        "runtime.(*unwinder).initAt+0 in /usr/local/go/src/runtime/traceback.go:225",
+        "runtime.callers.func1+0 in /usr/local/go/src/runtime/traceback.go:1100",
+        "runtime.systemstack+0 in /usr/local/go/src/runtime/asm_arm64.s:297",
+        "runtime.callers+0 in /usr/local/go/src/runtime/traceback.go:1102",
+        "main.main+0 in /home/tintin/ebpf/tools/coredump/testsources/go/systemstack/main.go:16",
+        "runtime.main+0 in /usr/local/go/src/internal/runtime/atomic/types.go:194",
+        "runtime.goexit+0 in /usr/local/go/src/runtime/asm_arm64.s:1269"
+      ]
+    },
+    {
+      "lwp": 6422,
+      "frames": [
+        "runtime.futex+0 in /usr/local/go/src/runtime/sys_linux_arm64.s:651",
+        "runtime.notesleep+0 in /usr/local/go/src/runtime/lock_futex.go:48",
+        "runtime.templateThread+0 in /usr/local/go/src/runtime/lock_spinbit.go:152",
+        "runtime.mstart1+0 in /usr/local/go/src/runtime/proc.go:1931",
+        "runtime.mstart0+0 in /usr/local/go/src/runtime/proc.go:1858",
+        "runtime.mstart+0 in /usr/local/go/src/runtime/asm_arm64.s:180"
+      ]
+    },
+    {
+      "lwp": 6420,
+      "frames": [
+        "runtime.futex+0 in /usr/local/go/src/runtime/sys_linux_arm64.s:651",
+        "runtime.notesleep+0 in /usr/local/go/src/runtime/lock_futex.go:48",
+        "runtime.stopm+0 in /usr/local/go/src/runtime/proc.go:1961",
+        "runtime.findRunnable+0 in /usr/local/go/src/runtime/proc.go:3374",
+        "runtime.schedule+0 in /usr/local/go/src/runtime/proc.go:4138",
+        "runtime.mstart1+0 in /usr/local/go/src/runtime/proc.go:1936",
+        "runtime.mstart0+0 in /usr/local/go/src/runtime/proc.go:1858",
+        "runtime.mstart+0 in /usr/local/go/src/runtime/asm_arm64.s:180"
+      ]
+    },
+    {
+      "lwp": 6419,
+      "frames": [
+        "runtime.futex+0 in /usr/local/go/src/runtime/sys_linux_arm64.s:651",
+        "runtime.notesleep+0 in /usr/local/go/src/runtime/lock_futex.go:48",
+        "runtime.stopm+0 in /usr/local/go/src/runtime/proc.go:1961",
+        "runtime.findRunnable+0 in /usr/local/go/src/runtime/proc.go:3374",
+        "runtime.schedule+0 in /usr/local/go/src/runtime/proc.go:4138",
+        "runtime.park_m+0 in /usr/local/go/src/runtime/proc.go:4267",
+        "runtime.mcall+0 in /usr/local/go/src/runtime/asm_arm64.s:242"
+      ]
+    },
+    {
+      "lwp": 6418,
+      "frames": [
+        "runtime.futex+0 in /usr/local/go/src/runtime/sys_linux_arm64.s:651",
+        "runtime.notesleep+0 in /usr/local/go/src/runtime/lock_futex.go:48",
+        "runtime.stopm+0 in /usr/local/go/src/runtime/proc.go:1961",
+        "runtime.startlockedm+0 in /usr/local/go/src/runtime/proc.go:3283",
+        "runtime.schedule+0 in /usr/local/go/src/runtime/proc.go:4128",
+        "runtime.park_m+0 in /usr/local/go/src/runtime/proc.go:4267",
+        "runtime.mcall+0 in /usr/local/go/src/runtime/asm_arm64.s:242"
+      ]
+    },
+    {
+      "lwp": 6417,
+      "frames": [
+        "runtime.futex+0 in /usr/local/go/src/runtime/sys_linux_arm64.s:651",
+        "runtime.notesleep+0 in /usr/local/go/src/runtime/lock_futex.go:48",
+        "runtime.stopm+0 in /usr/local/go/src/runtime/proc.go:1961",
+        "runtime.startlockedm+0 in /usr/local/go/src/runtime/proc.go:3283",
+        "runtime.schedule+0 in /usr/local/go/src/runtime/proc.go:4128",
+        "runtime.park_m+0 in /usr/local/go/src/runtime/proc.go:4267",
+        "runtime.mcall+0 in /usr/local/go/src/runtime/asm_arm64.s:242"
+      ]
+    },
+    {
+      "lwp": 6416,
+      "frames": [
+        "runtime.usleep+0 in /usr/local/go/src/runtime/sys_linux_arm64.s:138",
+        "runtime.sysmon+0 in /usr/local/go/src/runtime/proc.go:6251",
+        "runtime.mstart1+0 in /usr/local/go/src/runtime/proc.go:1931",
+        "runtime.mstart0+0 in /usr/local/go/src/runtime/proc.go:1858",
+        "runtime.mstart+0 in /usr/local/go/src/runtime/asm_arm64.s:180"
+      ]
+    }
+  ],
+  "modules": [
+    {
+      "ref": "1429e0cd0849978b68f09b3a32ef4da047b3fb2932813cc58b707b68a1678998",
+      "local-path": "/home/tintin/ebpf/test-systemstack"
+    }
+  ]
+}

--- a/tools/coredump/testsources/go/systemstack/main.go
+++ b/tools/coredump/testsources/go/systemstack/main.go
@@ -1,0 +1,18 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"runtime"
+)
+
+func main() {
+	runtime.GOMAXPROCS(1)
+	runtime.LockOSThread()
+
+	pcs := make([]uintptr, 32)
+	for {
+		runtime.Callers(0, pcs)
+	}
+}


### PR DESCRIPTION
Following the commit that was merged upstream to fix the unwinding issue for `runtime.systemstack`.