### PR TITLE
feat: overlay thread context onto process resource

### DIFF
--- a/libpf/trace.go
+++ b/libpf/trace.go
@@ -101,32 +101,34 @@ func (frames *Frames) Append(frame *Frame) {
 
 // Trace represents a stack trace.
 type Trace struct {
-	CustomLabels map[String]String
-	Frames       Frames
-	Hash         TraceHash
+	CustomLabels                  map[String]String
+	CustomLabelsFromThreadContext bool
+	Frames                        Frames
+	Hash                          TraceHash
 }
 
 // EbpfTrace represents a stack trace from Ebpf code.
 type EbpfTrace struct {
-	EnvVars          map[String]String
-	ProcessName      String
-	ExecutablePath   String
-	ContainerID      String
-	CustomLabels     map[String]String
-	Comm             String
-	Resource         *pcommon.Resource
-	FrameData        []uint64
-	KernelFrames     Frames
-	FrameDataBuf     [3072]uint64
-	Value            int64
-	KTime            int64
-	CpuID            uint32
-	TID              PID
-	PID              PID
-	NumFrames        uint16
-	Origin           Origin
-	APMTraceID       APMTraceID
-	APMTransactionID APMTransactionID
+	EnvVars                       map[String]String
+	ProcessName                   String
+	ExecutablePath                String
+	ContainerID                   String
+	CustomLabels                  map[String]String
+	CustomLabelsFromThreadContext bool
+	Comm                          String
+	Resource                      *pcommon.Resource
+	FrameData                     []uint64
+	KernelFrames                  Frames
+	FrameDataBuf                  [3072]uint64
+	Value                         int64
+	KTime                         int64
+	CpuID                         uint32
+	TID                           PID
+	PID                           PID
+	NumFrames                     uint16
+	Origin                        Origin
+	APMTraceID                    APMTraceID
+	APMTransactionID              APMTransactionID
 }
 
 type EbpfFrame []uint64

--- a/processmanager/manager.go
+++ b/processmanager/manager.go
@@ -347,8 +347,9 @@ func (pm *ProcessManager) HandleTrace(bpfTrace *libpf.EbpfTrace) {
 	pid := bpfTrace.PID
 	kernelFramesLen := len(bpfTrace.KernelFrames)
 	trace := &libpf.Trace{
-		Frames:       make(libpf.Frames, kernelFramesLen, kernelFramesLen+int(bpfTrace.NumFrames)),
-		CustomLabels: bpfTrace.CustomLabels,
+		Frames:                        make(libpf.Frames, kernelFramesLen, kernelFramesLen+int(bpfTrace.NumFrames)),
+		CustomLabels:                  bpfTrace.CustomLabels,
+		CustomLabelsFromThreadContext: bpfTrace.CustomLabelsFromThreadContext,
 	}
 	copy(trace.Frames, bpfTrace.KernelFrames)
 

--- a/reporter/base_reporter.go
+++ b/reporter/base_reporter.go
@@ -6,7 +6,11 @@ package reporter // import "go.opentelemetry.io/ebpf-profiler/reporter"
 import (
 	"errors"
 	"fmt"
+	"sort"
+	"strings"
 	"time"
+
+	"go.opentelemetry.io/collector/pdata/pcommon"
 
 	"go.opentelemetry.io/ebpf-profiler/libpf"
 	"go.opentelemetry.io/ebpf-profiler/libpf/xsync"
@@ -43,8 +47,103 @@ type baseReporter struct {
 
 var errUnknownOrigin = errors.New("unknown trace origin")
 
+const (
+	serviceNameKey               = "service.name"
+	serviceVersionKey            = "service.version"
+	deploymentEnvironmentNameKey = "deployment.environment.name"
+)
+
+var promotedThreadResourceAttributes = map[string]struct{}{
+	serviceNameKey:               {},
+	serviceVersionKey:            {},
+	deploymentEnvironmentNameKey: {},
+}
+
 func (b *baseReporter) Stop() {
 	b.runLoop.Stop()
+}
+
+// effectiveResource returns a per-sample resource in precedence order:
+// Process Context, SDK-published Thread Context, then the legacy APM service
+// name as a fallback when service.name is absent or empty.
+//
+// Process Context resources are shared and immutable, so this function copies
+// before applying overrides. A Thread Context attribute replaces a same-named
+// Process Context attribute. The resource-semantic attributes consumed by the
+// profiler are also promoted when absent from Process Context; all other Thread
+// Context attributes remain attached to the sample.
+func effectiveResource(
+	resource *pcommon.Resource,
+	apmServiceName string,
+	trace *libpf.Trace,
+) (*pcommon.Resource, libpf.String) {
+	hasThreadResourceAttribute := false
+	if trace.CustomLabelsFromThreadContext {
+		for key := range trace.CustomLabels {
+			name := key.String()
+			_, isPromoted := promotedThreadResourceAttributes[name]
+			existsInProcessResource := false
+			if resource != nil {
+				_, existsInProcessResource = resource.Attributes().Get(name)
+			}
+			if isPromoted || existsInProcessResource {
+				hasThreadResourceAttribute = true
+				break
+			}
+		}
+	}
+
+	if !hasThreadResourceAttribute {
+		if resourceString(resource, serviceNameKey) != "" || apmServiceName == "" {
+			return resource, libpf.NullString
+		}
+
+		effective := pcommon.NewResource()
+		if resource != nil {
+			resource.Attributes().CopyTo(effective.Attributes())
+		}
+		effective.Attributes().PutStr(serviceNameKey, apmServiceName)
+		return &effective, libpf.NullString
+	}
+
+	effective := pcommon.NewResource()
+	if resource != nil {
+		resource.Attributes().CopyTo(effective.Attributes())
+	}
+
+	var threadResourceParts []string
+	if trace.CustomLabelsFromThreadContext {
+		for key, value := range trace.CustomLabels {
+			name := key.String()
+			_, isPromoted := promotedThreadResourceAttributes[name]
+			_, existsInEffectiveResource := effective.Attributes().Get(name)
+			if isPromoted || existsInEffectiveResource {
+				valueString := value.String()
+				effective.Attributes().PutStr(name, valueString)
+				threadResourceParts = append(threadResourceParts,
+					fmt.Sprintf("%d:%s%d:%s", len(name), name, len(valueString), valueString))
+			}
+		}
+	}
+	if resourceString(&effective, serviceNameKey) == "" && apmServiceName != "" {
+		effective.Attributes().PutStr(serviceNameKey, apmServiceName)
+	}
+	if len(threadResourceParts) == 0 {
+		return &effective, libpf.NullString
+	}
+	sort.Strings(threadResourceParts)
+	return &effective, libpf.Intern(strings.Join(threadResourceParts, ""))
+}
+
+func resourceString(resource *pcommon.Resource, key string) string {
+	if resource == nil {
+		return ""
+	}
+	value, ok := resource.Attributes().Get(key)
+	if !ok || value.Type() != pcommon.ValueTypeStr {
+		return ""
+	}
+	return value.Str()
 }
 
 func (b *baseReporter) ReportTraceEvent(trace *libpf.Trace, meta *samples.TraceEventMeta) error {
@@ -62,12 +161,16 @@ func (b *baseReporter) ReportTraceEvent(trace *libpf.Trace, meta *samples.TraceE
 		extraMeta = b.cfg.ExtraSampleAttrProd.CollectExtraSampleMeta(trace, meta)
 	}
 
+	resource, threadResourceKey := effectiveResource(meta.Resource, meta.APMServiceName, trace)
 	key := samples.ResourceKey{
-		APMServiceName: meta.APMServiceName,
-		ContainerID:    meta.ContainerID,
-		PID:            int64(meta.PID),
-		ExecutablePath: meta.ExecutablePath,
-		ContextKey:     processcontext.ResourceToContextKey(meta.Resource),
+		ServiceName:           resourceString(resource, serviceNameKey),
+		ServiceVersion:        resourceString(resource, serviceVersionKey),
+		DeploymentEnvironment: resourceString(resource, deploymentEnvironmentNameKey),
+		ContainerID:           meta.ContainerID,
+		PID:                   int64(meta.PID),
+		ExecutablePath:        meta.ExecutablePath,
+		ContextKey:            processcontext.ResourceToContextKey(resource),
+		ThreadResourceKey:     threadResourceKey,
 	}
 
 	eventsTree := b.traceEvents.WLock()
@@ -76,7 +179,7 @@ func (b *baseReporter) ReportTraceEvent(trace *libpf.Trace, meta *samples.TraceE
 	if _, exists := (*eventsTree)[key]; !exists {
 		(*eventsTree)[key] = samples.ResourceToProfiles{
 			EnvVars:  meta.EnvVars,
-			Resource: meta.Resource,
+			Resource: resource,
 			Events:   make(map[libpf.Origin]samples.SampleToEvents),
 		}
 	}

--- a/reporter/base_reporter_test.go
+++ b/reporter/base_reporter_test.go
@@ -246,3 +246,203 @@ func TestReportTraceEventResourceKeyContextKey(t *testing.T) {
 	assert.True(t, keys[libpf.Intern(":svc:")], "missing bucket for partial-triplet key")
 	assert.True(t, keys[libpf.NullString], "missing NullString bucket for nil resource")
 }
+
+func TestReportTraceEventThreadContextOverlaysProcessResource(t *testing.T) {
+	reporter := createTestBaseReporter(t, nil)
+
+	processResource := pcommon.NewResource()
+	processResource.Attributes().PutStr("service.name", "process-service")
+	processResource.Attributes().PutStr("service.version", "process-version")
+	processResource.Attributes().PutStr("deployment.environment.name", "process-env")
+	processResource.Attributes().PutStr("service.instance.id", "process-instance")
+	processResource.Attributes().PutStr("host.name", "process-host")
+	processResource.Attributes().PutStr("process-only", "unchanged")
+
+	trace := &libpf.Trace{
+		Hash:                          libpf.NewTraceHash(0x1, 0x0),
+		CustomLabelsFromThreadContext: true,
+		CustomLabels: map[libpf.String]libpf.String{
+			libpf.Intern("service.name"):                libpf.Intern("thread-service"),
+			libpf.Intern("service.version"):             libpf.Intern("thread-version"),
+			libpf.Intern("deployment.environment.name"): libpf.Intern("thread-env"),
+			libpf.Intern("service.instance.id"):         libpf.Intern("thread-instance"),
+			libpf.Intern("host.name"):                   libpf.Intern("thread-host"),
+			libpf.Intern("http.route"):                  libpf.Intern("/not-a-resource"),
+		},
+	}
+	meta := &samples.TraceEventMeta{
+		Timestamp:      libpf.UnixTime64(time.Now().UnixNano()),
+		ExecutablePath: libpf.Intern("/usr/bin/php"),
+		APMServiceName: "legacy-apm-service",
+		PID:            1234,
+		TID:            1235,
+		Origin:         support.TraceOriginSampling,
+		Resource:       &processResource,
+	}
+
+	require.NoError(t, reporter.ReportTraceEvent(trace, meta))
+
+	treePtr := reporter.traceEvents.RLock()
+	defer reporter.traceEvents.RUnlock(&treePtr)
+	tree := *treePtr
+	require.Len(t, tree, 1)
+
+	for key, profiles := range tree {
+		assert.Equal(t, "thread-service", key.ServiceName)
+		assert.Equal(t, "thread-version", key.ServiceVersion)
+		assert.Equal(t, "thread-env", key.DeploymentEnvironment)
+		assert.Equal(t, ":thread-service:thread-instance", key.ContextKey.String())
+
+		require.NotNil(t, profiles.Resource)
+		assert.Equal(t, map[string]any{
+			"service.name":                "thread-service",
+			"service.version":             "thread-version",
+			"deployment.environment.name": "thread-env",
+			"service.instance.id":         "thread-instance",
+			"host.name":                   "thread-host",
+			"process-only":                "unchanged",
+		}, profiles.Resource.Attributes().AsRaw())
+		_, promoted := profiles.Resource.Attributes().Get("http.route")
+		assert.False(t, promoted, "sample-only attributes must not be promoted")
+	}
+
+	// The shared Process Context resource remains immutable.
+	assert.Equal(t, "process-service",
+		processResource.Attributes().AsRaw()["service.name"])
+	assert.Equal(t, "process-host",
+		processResource.Attributes().AsRaw()["host.name"])
+}
+
+func TestReportTraceEventThreadResourceOverridesCreateDistinctBuckets(t *testing.T) {
+	reporter := createTestBaseReporter(t, nil)
+	processResource := pcommon.NewResource()
+	processResource.Attributes().PutStr("service.name", "process-service")
+
+	meta := &samples.TraceEventMeta{
+		Timestamp: libpf.UnixTime64(time.Now().UnixNano()),
+		PID:       1234,
+		TID:       1235,
+		Origin:    support.TraceOriginSampling,
+		Resource:  &processResource,
+	}
+	makeTrace := func(version string) *libpf.Trace {
+		return &libpf.Trace{
+			Hash:                          libpf.NewTraceHash(0x1, 0x0),
+			CustomLabelsFromThreadContext: true,
+			CustomLabels: map[libpf.String]libpf.String{
+				libpf.Intern("service.version"): libpf.Intern(version),
+			},
+		}
+	}
+
+	require.NoError(t, reporter.ReportTraceEvent(makeTrace("v1"), meta))
+	require.NoError(t, reporter.ReportTraceEvent(makeTrace("v2"), meta))
+
+	treePtr := reporter.traceEvents.RLock()
+	defer reporter.traceEvents.RUnlock(&treePtr)
+	assert.Len(t, *treePtr, 2)
+}
+
+func TestReportTraceEventAPMServiceNameIsFallback(t *testing.T) {
+	stringPtr := func(value string) *string {
+		return &value
+	}
+	tests := []struct {
+		name           string
+		processService string
+		threadService  *string
+		expected       string
+	}{
+		{
+			name:           "process context wins",
+			processService: "process-service",
+			expected:       "process-service",
+		},
+		{
+			name:     "APM fills missing service",
+			expected: "legacy-apm-service",
+		},
+		{
+			name:           "thread context wins",
+			processService: "process-service",
+			threadService:  stringPtr("thread-service"),
+			expected:       "thread-service",
+		},
+		{
+			name:           "APM fills service cleared by thread context",
+			processService: "process-service",
+			threadService:  stringPtr(""),
+			expected:       "legacy-apm-service",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			reporter := createTestBaseReporter(t, nil)
+			processResource := pcommon.NewResource()
+			if test.processService != "" {
+				processResource.Attributes().PutStr("service.name", test.processService)
+			}
+
+			trace := &libpf.Trace{Hash: libpf.NewTraceHash(0x1, 0x0)}
+			if test.threadService != nil {
+				trace.CustomLabelsFromThreadContext = true
+				trace.CustomLabels = map[libpf.String]libpf.String{
+					libpf.Intern("service.name"): libpf.Intern(*test.threadService),
+				}
+			}
+			meta := &samples.TraceEventMeta{
+				Timestamp:      libpf.UnixTime64(time.Now().UnixNano()),
+				APMServiceName: "legacy-apm-service",
+				PID:            1234,
+				TID:            1235,
+				Origin:         support.TraceOriginSampling,
+				Resource:       &processResource,
+			}
+
+			require.NoError(t, reporter.ReportTraceEvent(trace, meta))
+
+			treePtr := reporter.traceEvents.RLock()
+			defer reporter.traceEvents.RUnlock(&treePtr)
+			require.Len(t, *treePtr, 1)
+			for key, profiles := range *treePtr {
+				assert.Equal(t, test.expected, key.ServiceName)
+				require.NotNil(t, profiles.Resource)
+				assert.Equal(t, test.expected,
+					profiles.Resource.Attributes().AsRaw()["service.name"])
+			}
+		})
+	}
+}
+
+func TestReportTraceEventGoLabelsDoNotOverrideResource(t *testing.T) {
+	reporter := createTestBaseReporter(t, nil)
+	processResource := pcommon.NewResource()
+	processResource.Attributes().PutStr("service.name", "process-service")
+
+	trace := &libpf.Trace{
+		Hash: libpf.NewTraceHash(0x1, 0x0),
+		CustomLabels: map[libpf.String]libpf.String{
+			libpf.Intern("service.name"): libpf.Intern("go-label-service"),
+		},
+	}
+	meta := &samples.TraceEventMeta{
+		Timestamp:      libpf.UnixTime64(time.Now().UnixNano()),
+		APMServiceName: "legacy-apm-service",
+		PID:            1234,
+		TID:            1235,
+		Origin:         support.TraceOriginSampling,
+		Resource:       &processResource,
+	}
+
+	require.NoError(t, reporter.ReportTraceEvent(trace, meta))
+
+	treePtr := reporter.traceEvents.RLock()
+	defer reporter.traceEvents.RUnlock(&treePtr)
+	require.Len(t, *treePtr, 1)
+	for key, profiles := range *treePtr {
+		assert.Equal(t, "process-service", key.ServiceName)
+		assert.Equal(t, "process-service",
+			profiles.Resource.Attributes().AsRaw()["service.name"])
+	}
+}

--- a/reporter/internal/pdata/generate.go
+++ b/reporter/internal/pdata/generate.go
@@ -303,8 +303,8 @@ func setResourceAttributes(attrs pcommon.Map, resource samples.ResourceKey, envV
 	if res != nil {
 		res.Attributes().CopyTo(attrs)
 	}
-	if resource.APMServiceName != "" {
-		attrs.PutStr(string(semconv.ServiceNameKey), resource.APMServiceName)
+	if resource.ServiceName != "" {
+		attrs.PutStr(string(semconv.ServiceNameKey), resource.ServiceName)
 	}
 	if resource.ContainerID != libpf.NullString {
 		attrs.PutStr(string(semconv.ContainerIDKey), resource.ContainerID.String())

--- a/reporter/internal/pdata/generate_test.go
+++ b/reporter/internal/pdata/generate_test.go
@@ -375,7 +375,7 @@ func TestGenerate_SingleContainerSingleOrigin(t *testing.T) {
 	resourceKey := samples.ResourceKey{
 		ExecutablePath: filePath,
 		PID:            123,
-		APMServiceName: "svc",
+		ServiceName:    "svc",
 		ContainerID:    libpf.Intern("container1"),
 	}
 	events := map[libpf.Origin]samples.SampleToEvents{
@@ -917,7 +917,7 @@ func TestGenerate_ProcessContextResource_NilResource(t *testing.T) {
 	tree := singleEventTree(samples.ResourceKey{
 		ExecutablePath: libpf.Intern("/bin/svc"),
 		PID:            99,
-		APMServiceName: "apm-svc",
+		ServiceName:    "apm-svc",
 	}, nil)
 
 	profiles, err := testGenerate(d, tree, "agent", "v1")

--- a/reporter/samples/attrmgr_test.go
+++ b/reporter/samples/attrmgr_test.go
@@ -29,8 +29,8 @@ func TestAttrTableManager(t *testing.T) {
 		"empty": {
 			k: []ResourceKey{
 				{
-					APMServiceName: "",
-					PID:            0,
+					ServiceName: "",
+					PID:         0,
 				},
 			},
 			expectedIndices: [][]int32{{0}},
@@ -41,12 +41,12 @@ func TestAttrTableManager(t *testing.T) {
 		"duplicate": {
 			k: []ResourceKey{
 				{
-					APMServiceName: "APMServiceName1",
-					PID:            1234,
+					ServiceName: "APMServiceName1",
+					PID:         1234,
 				},
 				{
-					APMServiceName: "APMServiceName1",
-					PID:            1234,
+					ServiceName: "APMServiceName1",
+					PID:         1234,
 				},
 			},
 			expectedIndices: [][]int32{{0, 1}, {0, 1}},
@@ -58,12 +58,12 @@ func TestAttrTableManager(t *testing.T) {
 		"different": {
 			k: []ResourceKey{
 				{
-					APMServiceName: "APMServiceName1",
-					PID:            1234,
+					ServiceName: "APMServiceName1",
+					PID:         1234,
 				},
 				{
-					APMServiceName: "APMServiceName2",
-					PID:            6789,
+					ServiceName: "APMServiceName2",
+					PID:         6789,
 				},
 			},
 			expectedIndices: [][]int32{{0, 1}, {2, 3}},
@@ -84,7 +84,7 @@ func TestAttrTableManager(t *testing.T) {
 			indices := make([][]int32, 0)
 			for _, k := range tc.k {
 				inner := pcommon.NewInt32Slice()
-				mgr.AppendOptionalString(inner, semconv.ServiceNameKey, k.APMServiceName)
+				mgr.AppendOptionalString(inner, semconv.ServiceNameKey, k.ServiceName)
 				mgr.AppendInt(inner, semconv.ProcessPIDKey, k.PID)
 				indices = append(indices, inner.AsRaw())
 			}

--- a/reporter/samples/samples.go
+++ b/reporter/samples/samples.go
@@ -66,11 +66,20 @@ type ResourceKey struct {
 	// Executable path is retrieved from /proc/PID/exe
 	ExecutablePath libpf.String
 
-	// APMServiceName is provided by the eBPF programs
-	APMServiceName string
+	// ServiceName is the effective service name after applying all sources.
+	ServiceName string
+
+	// ServiceVersion and DeploymentEnvironment distinguish effective resources
+	// after thread-context attributes have been overlaid.
+	ServiceVersion        string
+	DeploymentEnvironment string
 
 	// ContextKey is the unique identifier for a service instance
 	ContextKey libpf.String
+
+	// ThreadResourceKey distinguishes per-thread overrides of the process
+	// resource within the same service instance.
+	ThreadResourceKey libpf.String
 
 	PID int64
 }

--- a/tracer/tracer.go
+++ b/tracer/tracer.go
@@ -1083,6 +1083,7 @@ func (t *Tracer) loadBpfTrace(raw []byte) (*libpf.EbpfTrace, error) {
 		}
 	case support.CustomLabelsTypeNative:
 		trace.CustomLabels = procMeta.ProcessContextInfo.DecodeThreadLabels(ptr.Custom_labels_data.Data[:ptr.Custom_labels_data.Size])
+		trace.CustomLabelsFromThreadContext = true
 	}
 
 	trace.NumFrames = ptr.Num_frames


### PR DESCRIPTION
[PROF-15496](https://datadoghq.atlassian.net/browse/PROF-15496)

### Summary

Certain process context resource attributes with like `service.name` and `deployment.environment.name` can now be overwritten by thread context attributes.

### Motivation

In PHP, every request that comes can change what service, env, and version are set (among other properties). There are various reasons for this, such as config changes, but also more dynamic situations like splitting these requests to different services:

 - `GET /products` -> `storefront`
 - `POST /admin/users` -> `storefront-admin`
 
The PHP SDK also has APIs to set these properties (service, env, version, etc) programmatically.

So for these reasons, in PHP we don't set the `service.name`, `service.version`, and `deployment.environment.name` in the process context resource attributes and set them instead in the thread context.

### Notes

I am not fluent in Go so I had an AI agent do the work. One thing that should definitely be looked at is priority of values. The intent of my commit was to have the priority be APM -> Thread Context -> Process Context (highest to lowest).

[PROF-15496]: https://datadoghq.atlassian.net/browse/PROF-15496?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ